### PR TITLE
fix(packaging): suggest the GNOME hosts instead of recommending them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       # on Cargo.lock; the prefix restore-key still yields a warm registry and
       # most of target/ when a single dependency moved.
       - name: Cache the cargo registry and build artefacts
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry/index

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -125,7 +125,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends fuse3 libfuse3-dev pkg-config
       - name: Cache the cargo registry and build artefacts
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry/index

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
           # Nothing here pushes, and everything here compiles third-party code.
           persist-credentials: false
       - name: Cache the cargo registry and build artefacts
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry/index
@@ -100,7 +100,7 @@ jobs:
       - name: Build the RPM
         run: ./packaging/rpm/build-rpm.sh
       - name: Upload the RPM artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rpm-${{ matrix.arch }}
           path: dist/*.rpm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2847,7 +2847,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wusel"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2864,7 +2864,7 @@ dependencies = [
 
 [[package]]
 name = "wusel-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "diffy",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "wusel-desktop"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "tracing",
  "wusel-core",
@@ -2898,11 +2898,11 @@ dependencies = [
 
 [[package]]
 name = "wusel-fsm"
-version = "0.2.1"
+version = "0.2.2"
 
 [[package]]
 name = "wusel-fuse"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "fuser",
@@ -2917,7 +2917,7 @@ dependencies = [
 
 [[package]]
 name = "wusel-mock"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "reqwest",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 # simply does not get it, so a new field added below is only live once the crate
 # manifests reference it.
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.97"
 license = "Apache-2.0"

--- a/documentation/modules/ROOT/pages/changelog.adoc
+++ b/documentation/modules/ROOT/pages/changelog.adoc
@@ -12,6 +12,18 @@ the RPM is terse because a package changelog is, this page has room to say why.
 The format follows https://keepachangelog.com/en/1.1.0/[Keep a Changelog]; the
 project uses https://semver.org/[Semantic Versioning].
 
+== 0.2.2 — 2026-08-24
+
+=== Fixed
+
+* **Installing no longer drags in a desktop you did not ask for.** The Nautilus
+  extension and the GNOME Shell search provider were declared as `Recommends`,
+  and `dnf` installs weak dependencies by default — so on a server, a minimal
+  install or a KDE machine, a client whose only stated dependency is `fuse3`
+  pulled in several hundred packages, GNOME Shell among them. They are now
+  `Suggests`. On a desktop that already runs GNOME Files nothing changes; the
+  extension and the search provider work exactly as before.
+
 == 0.2.1 — 2026-08-24
 
 === Changed

--- a/documentation/modules/ROOT/pages/installation.adoc
+++ b/documentation/modules/ROOT/pages/installation.adoc
@@ -32,6 +32,12 @@ xref:distribution.adoc[Project, licence & distribution] and
 sudo dnf install ./wusel-*.rpm
 ----
 
+The GNOME pieces are *suggested*, not required, so a machine without GNOME gets
+the mount and nothing else — roughly five packages, since the only stated
+dependency is `fuse3`. On a desktop that already runs GNOME Files nothing extra
+is pulled in either. (Before 0.2.2 these were `Recommends`, which `dnf` installs
+by default; on a server or a KDE machine that meant several hundred packages.)
+
 The one dependency the spec states explicitly is `fuse3`, for the setuid
 `fusermount3` helper the unprivileged mount needs; the shared libraries the
 binary and the Nautilus extension link against come in automatically as

--- a/packaging/rpm/wusel.spec
+++ b/packaging/rpm/wusel.spec
@@ -31,9 +31,13 @@ ExclusiveArch:  x86_64 aarch64
 # come in automatically as auto-generated soname dependencies of the binary/.so.
 Requires:       fuse3
 # The Nautilus extension and GNOME Shell search provider live in this package;
-# they are inert without their host, so pull them softly rather than hard.
-Recommends:     nautilus
-Recommends:     gnome-shell
+# they are inert without their host. `Suggests` rather than `Recommends`, because
+# dnf installs weak dependencies by default: on a desktop these are already
+# present and the difference is invisible, but on a server, a minimal install or
+# a KDE machine `Recommends` drags in the whole GNOME stack — several hundred
+# packages — for a mount that needs `fuse3` and nothing else.
+Suggests:       nautilus
+Suggests:       gnome-shell
 
 %description
 Wusel makes a Nextcloud appear as an ordinary folder on Linux — VFS-first:
@@ -94,6 +98,10 @@ fi
 # with no system-wide preset to apply; each user enables their own instance.
 
 %changelog
+* Mon Aug 24 2026 Christoph D. Hermann <christoph.hermann@itbh.at> - 0.2.2-1
+- The GNOME hosts are suggested rather than recommended, so installing on a
+  machine without GNOME no longer pulls in the whole desktop stack.
+
 * Mon Aug 24 2026 Christoph D. Hermann <christoph.hermann@itbh.at> - 0.2.1-1
 - Wusel ships its own application icon; the file-manager sidebar entry and the
   GNOME search entry no longer fall back to the generic folder-remote icon.


### PR DESCRIPTION
`dnf` installs weak dependencies by default, so declaring the Nautilus extension
and the GNOME Shell search provider as `Recommends` turned a five-package
install into several hundred on any machine that does not already run GNOME — a
server, a minimal install, or a KDE desktop, none of which can use the Nautilus
extension at all. They are `Suggests` now. On a desktop running GNOME Files
nothing changes; the mount itself needs `fuse3` and nothing else.

Also here: the pinned actions/cache and actions/upload-artifact are updated —
the release workflow already downloaded artifacts with v8 while uploading with
v4.