### PR TITLE
fix(e2e): close the step 12 guard around the whole step

### DIFF
--- a/scripts/e2e-nextcloud.sh
+++ b/scripts/e2e-nextcloud.sh
@@ -507,10 +507,10 @@ echo ">> parallel ${t_par}ms vs sequential ${t_seq}ms (informational; see the mo
 if [ "$t_par" -lt "$t_seq" ]; then
     ok "concurrent transfers overlapped (${t_par}ms < ${t_seq}ms)"
 else
-    skip "step 12 - overlap of concurrent transfers under added latency"
+    echo ">> note: parallel was not faster this run (${t_par}ms vs ${t_seq}ms) — expected on a throughput-throttled link; the deterministic proof is the mock test"
 fi
 else
-    echo ">> note: parallel was not faster this run (${t_par}ms vs ${t_seq}ms) — expected on a throughput-throttled link; the deterministic proof is the mock test"
+    skip "step 12 - overlap of concurrent transfers under added latency"
 fi
 
 if [ "$SKIPPED" -gt 0 ]; then


### PR DESCRIPTION
Guarding the throttled end-to-end steps split step 12's own if/else: the
guard's `else` landed inside it, and its `else` closed the guard. With shaping
unavailable the step never ran, yet the branch reporting its timings still did,
and the run failed on an unset variable after everything had passed or been
skipped as intended.