### PR TITLE
fix(deb): keep the vendored manifests through dh_clean, and install from the repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "wusel"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "wusel-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bytes",
  "diffy",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "wusel-desktop"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tracing",
  "wusel-core",
@@ -2753,11 +2753,11 @@ dependencies = [
 
 [[package]]
 name = "wusel-fsm"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "wusel-fuse"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "fuser",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "wusel-mock"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "reqwest",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 # simply does not get it, so a new field added below is only live once the crate
 # manifests reference it.
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 # Distro packaging (RPM/DEB from source, COPR/OBS/AUR) needs this to be the true
 # floor, not "whatever mise happened to pin at scaffold time" (it was 1.97, an

--- a/documentation/modules/ROOT/pages/how-to/install-a-package.adoc
+++ b/documentation/modules/ROOT/pages/how-to/install-a-package.adoc
@@ -4,13 +4,16 @@
 ////
 
 = Install a package
-:description: Install Wusel from an RPM, a .deb or the Arch PKGBUILD — one command per package family.
+:description: Add the Wusel repository and install with your own package manager — Fedora, openSUSE, Debian, Ubuntu — or take a single file for anything else.
 
-Get the file for your architecture from the
-https://github.com/itbh-at/wusel/releases/latest[latest release].
-xref:reference/packages.adoc[Packages] says which file is built for what; if
-none of them fits your distribution, see
-xref:how-to/install-from-source.adoc[Install from source] instead.
+Wusel is published as a *signed repository* through the openSUSE Build Service,
+so your package manager installs it and keeps it up to date like anything else
+on the machine. Pick your family below; each is two commands.
+
+If your distribution is not one of the four, skip to <<single-file>> or build
+from source: xref:how-to/install-from-source.adoc[Install from source].
+xref:reference/packages.adoc[Packages] is the full table of what is published
+where.
 
 Installing does not switch Wusel on. Do
 xref:how-to/mount-at-login.adoc[Mount at login] afterwards — or follow a
@@ -19,22 +22,51 @@ xref:tutorials/on-gnome.adoc[on GNOME],
 xref:tutorials/on-another-desktop.adoc[on another desktop] or
 xref:tutorials/on-a-server.adoc[on a server].
 
-== RPM-based (Fedora, and relatives)
+== Fedora
 
 [source,sh]
 ----
-sudo dnf install ./wusel-*.rpm
+sudo dnf config-manager addrepo --from-repofile=https://download.opensuse.org/repositories/home:/cdhermann:/wusel/Fedora_44/home:cdhermann:wusel.repo
+sudo dnf install wusel
 ----
 
-== Debian-based (Debian, Ubuntu)
+The repository is built for Fedora 44. `dnf` imports the signing key on first
+install and asks you to confirm its fingerprint.
+
+== openSUSE Tumbleweed
 
 [source,sh]
 ----
-sudo apt install ./wusel_*.deb
+sudo zypper addrepo https://download.opensuse.org/repositories/home:/cdhermann:/wusel/openSUSE_Tumbleweed/home:cdhermann:wusel.repo
+sudo zypper refresh
+sudo zypper install wusel
 ----
 
-Use `apt`, not `dpkg -i`. `apt` resolves the dependencies; `dpkg` only reports
-that they are missing.
+== Debian 13
+
+[source,sh]
+----
+echo 'deb http://download.opensuse.org/repositories/home:/cdhermann:/wusel/Debian_13/ /' \
+  | sudo tee /etc/apt/sources.list.d/home:cdhermann:wusel.list
+curl -fsSL https://download.opensuse.org/repositories/home:cdhermann:wusel/Debian_13/Release.key \
+  | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_cdhermann_wusel.gpg > /dev/null
+sudo apt update
+sudo apt install wusel
+----
+
+== Ubuntu 26.04
+
+The same, against the Ubuntu repository:
+
+[source,sh]
+----
+echo 'deb http://download.opensuse.org/repositories/home:/cdhermann:/wusel/xUbuntu_26.04/ /' \
+  | sudo tee /etc/apt/sources.list.d/home:cdhermann:wusel.list
+curl -fsSL https://download.opensuse.org/repositories/home:cdhermann:wusel/xUbuntu_26.04/Release.key \
+  | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_cdhermann_wusel.gpg > /dev/null
+sudo apt update
+sudo apt install wusel
+----
 
 == Arch Linux
 
@@ -50,7 +82,65 @@ makepkg -si
 ----
 
 `-s` installs the build dependencies through `pacman` first; `-i` installs the
-result.
+result. Updating means pulling and running it again.
+
+[[single-file]]
+== A single file, for everything else
+
+Every release also attaches one RPM and one `.deb` per architecture to its
+https://github.com/itbh-at/wusel/releases/latest[GitHub Release]. These are
+*unsigned*, and nothing updates them for you — fetch the next release the same
+way. Use them when you cannot add a repository, or when your distribution is
+none of the four above and is close enough to Fedora 44 or Debian 13 to run
+one.
+
+[source,sh]
+----
+sudo dnf install ./wusel-*.rpm      # RPM-based
+sudo apt install ./wusel_*.deb      # Debian-based
+----
+
+Use `apt`, not `dpkg -i`. `apt` resolves the dependencies; `dpkg` only reports
+that they are missing.
+
+== Staying up to date
+
+This is the point of the repository, and it needs no further setup: Wusel is now
+an ordinary package on the machine, so whatever you already run to update the
+system picks up each new release.
+
+[cols="1,2",options="header"]
+|===
+| Distribution | Updates arrive with
+
+| Fedora
+| `sudo dnf upgrade` — or GNOME Software / the automatic updates you already
+  have configured.
+
+| openSUSE Tumbleweed
+| `sudo zypper dup`, as with the rest of the system.
+
+| Debian, Ubuntu
+| `sudo apt update && sudo apt upgrade`, or unattended-upgrades.
+
+| Arch
+| Nothing automatic. `makepkg -si` again in a fresh checkout; the AUR would
+  change that, and is a xref:project/roadmap.adoc[roadmap] item.
+
+| A single file from a GitHub Release
+| Nothing. Download the next one and install it over the top.
+|===
+
+A new version does not restart your mount. After an update, either log out and
+back in, or:
+
+[source,sh]
+----
+systemctl --user restart wusel@default
+----
+
+The Nautilus extension and the search provider are loaded at session start, so
+a full re-login is what picks *those* up — see below.
 
 == Then log out and back in
 
@@ -70,6 +160,3 @@ neither package manager installs them by default: on a server or a KDE machine
 you get the mount and about five packages rather than a desktop stack. What is
 then missing is the sidebar entry, the emblems and the Shell search — not the
 filesystem. See xref:reference/platform-support.adoc[Platform support].
-
-These are unsigned community packages with no repository behind them, so your
-package manager will not update them. Fetch the next release the same way.

--- a/documentation/modules/ROOT/pages/project/changelog.adoc
+++ b/documentation/modules/ROOT/pages/project/changelog.adoc
@@ -13,6 +13,33 @@ the RPM is terse because a package changelog is, this page has room to say why.
 The format follows https://keepachangelog.com/en/1.1.0/[Keep a Changelog]; the
 project uses https://semver.org/[Semantic Versioning].
 
+== 0.3.1 — 2026-08-26
+
+=== Added
+
+* **Install from a signed repository, and get updates with the rest of the
+  system.** Wusel is published through the openSUSE Build Service for Fedora 44,
+  openSUSE Tumbleweed, Debian 13 and Ubuntu 26.04, on `x86_64` and `aarch64`.
+  Adding the repository once means `dnf upgrade`, `zypper dup` or `apt upgrade`
+  picks up every later release, and each package is verified against the
+  repository's signing key. See
+  xref:how-to/install-a-package.adoc[Install a package].
++
+The single files attached to each GitHub Release stay, unsigned and
+self-updating by nobody, for machines that cannot add a repository and for
+distributions the build service does not target.
+
+=== Fixed
+
+* **The Debian and Ubuntu packages build again.** `dh_clean` removes `*.orig` —
+  patch leftovers, normally — and `cargo vendor` writes one per crate whose
+  manifest it rewrites, listing each in that crate's checksum manifest. Building
+  the source package runs `clean` first, so the tarball shipped without those
+  289 files and every rebuild from it failed on
+  `failed to calculate checksum of vendor/<crate>/Cargo.toml.orig`. The RPM was
+  unaffected, which is why 0.3.0 shipped with two of four distributions quietly
+  broken.
+
 == 0.3.0 — 2026-08-25
 
 === Added

--- a/documentation/modules/ROOT/pages/reference/packages.adoc
+++ b/documentation/modules/ROOT/pages/reference/packages.adoc
@@ -10,7 +10,48 @@ Every `v*` tag builds packages for `x86_64` and `aarch64` and attaches them to a
 https://github.com/itbh-at/wusel/releases/latest[GitHub Release]. To actually
 install one, see xref:how-to/install-a-package.adoc[Install a package].
 
-== What is published
+== The repository
+
+Wusel is published as a signed repository through the openSUSE Build Service, at
+`https://download.opensuse.org/repositories/home:/cdhermann:/wusel/`. Adding it
+is the normal way to install; see
+xref:how-to/install-a-package.adoc[Install a package].
+
+[cols="1,1,2",options="header"]
+|===
+| Distribution | Repository | Architectures
+
+| Fedora 44
+| `Fedora_44`
+| `x86_64`, `aarch64`
+
+| openSUSE Tumbleweed
+| `openSUSE_Tumbleweed`
+| `x86_64`, `aarch64`
+
+| Debian 13 (trixie)
+| `Debian_13`
+| `x86_64`, `aarch64`
+
+| Ubuntu 26.04
+| `xUbuntu_26.04`
+| `x86_64`, `aarch64`
+|===
+
+The RPM repositories carry `gpgcheck=1` and a signing key at
+`<repository>/repodata/repomd.xml.key`; the Debian ones a `Release.key`. Your
+package manager verifies every package against it, and updates arrive with the
+rest of the system.
+
+Arch is not in the build service. The `PKGBUILD` under `packaging/aur/` builds
+locally; the AUR itself is a xref:project/roadmap.adoc[roadmap] item.
+
+== Single files, per release
+
+Every `v*` tag also attaches one package per format and architecture to its
+https://github.com/itbh-at/wusel/releases/latest[GitHub Release]. These exist
+for machines that cannot add a repository, and for distributions the build
+service does not target.
 
 [cols="2,2,2",options="header"]
 |===
@@ -26,16 +67,10 @@ install one, see xref:how-to/install-a-package.adoc[Install a package].
 | Debian 13 (trixie), and Ubuntu releases close enough to it. A `.deb` filename
   carries no distribution of its own, which is why the target is spelled into
   it. On an older Ubuntu — 24.04 LTS among them — expect it not to run.
-
-| —
-| Arch `PKGBUILD`
-| Arch Linux. Not published as a file and not on the AUR yet; the recipe is in
-  the repository under `packaging/aur/` and is built locally.
 |===
 
-These are *unsigned community packages*, and there is no repository behind them
-yet — neither `dnf` nor `apt` will update them for you. If your distribution or
-release is not listed, build from source:
+These are *unsigned*, and nothing updates them for you. Prefer the repository
+wherever you can use it. If neither fits, build from source:
 xref:how-to/install-from-source.adoc[Install from source].
 
 == Dependencies

--- a/documentation/modules/ROOT/pages/tutorials/on-a-server.adoc
+++ b/documentation/modules/ROOT/pages/tutorials/on-a-server.adoc
@@ -51,20 +51,38 @@ disk for what it actually touches, not for the whole cloud.
 
 == Step 1 — Install the package
 
-Copy the file for your distribution and architecture onto the machine from the
-https://github.com/itbh-at/wusel/releases/latest[latest release]. RPM-based:
+Wusel is published as a signed repository, so your package manager installs it
+and keeps it updated like anything else. Run the block for your distribution.
+
+Fedora:
 
 [source,sh]
 ----
-sudo dnf install ./wusel-*.rpm
+sudo dnf config-manager addrepo --from-repofile=https://download.opensuse.org/repositories/home:/cdhermann:/wusel/Fedora_44/home:cdhermann:wusel.repo
+sudo dnf install wusel
 ----
 
-Debian-based:
+openSUSE Tumbleweed:
 
 [source,sh]
 ----
-sudo apt install ./wusel_*.deb
+sudo zypper addrepo https://download.opensuse.org/repositories/home:/cdhermann:/wusel/openSUSE_Tumbleweed/home:cdhermann:wusel.repo
+sudo zypper install wusel
 ----
+
+Debian 13 or Ubuntu 26.04 — substitute `xUbuntu_26.04` for `Debian_13` on Ubuntu:
+
+[source,sh]
+----
+echo 'deb http://download.opensuse.org/repositories/home:/cdhermann:/wusel/Debian_13/ /' \
+  | sudo tee /etc/apt/sources.list.d/home:cdhermann:wusel.list
+curl -fsSL https://download.opensuse.org/repositories/home:cdhermann:wusel/Debian_13/Release.key \
+  | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_cdhermann_wusel.gpg > /dev/null
+sudo apt update && sudo apt install wusel
+----
+
+Anything else — Arch, an older Ubuntu, a distribution not listed —
+xref:how-to/install-a-package.adoc[Install a package] has the remaining routes.
 
 You get the binary, the systemd unit and `fuse3` — about five packages. The
 GNOME pieces are *suggested*, not required, so nothing graphical is pulled onto

--- a/documentation/modules/ROOT/pages/tutorials/on-another-desktop.adoc
+++ b/documentation/modules/ROOT/pages/tutorials/on-another-desktop.adoc
@@ -40,23 +40,38 @@ get.
 
 == Step 1 — Install the package
 
-Download the file for your distribution and architecture from the
-https://github.com/itbh-at/wusel/releases/latest[latest release]. Then, for an
-RPM-based distribution:
+Wusel is published as a signed repository, so your package manager installs it
+and keeps it updated like anything else. Run the block for your distribution.
+
+Fedora:
 
 [source,sh]
 ----
-sudo dnf install ./wusel-*.rpm
+sudo dnf config-manager addrepo --from-repofile=https://download.opensuse.org/repositories/home:/cdhermann:/wusel/Fedora_44/home:cdhermann:wusel.repo
+sudo dnf install wusel
 ----
 
-For a Debian-based one:
+openSUSE Tumbleweed:
 
 [source,sh]
 ----
-sudo apt install ./wusel_*.deb
+sudo zypper addrepo https://download.opensuse.org/repositories/home:/cdhermann:/wusel/openSUSE_Tumbleweed/home:cdhermann:wusel.repo
+sudo zypper install wusel
 ----
 
-On Arch, build the recipe from the repository — `cd wusel/packaging/aur && makepkg -si`.
+Debian 13 or Ubuntu 26.04 — substitute `xUbuntu_26.04` for `Debian_13` on Ubuntu:
+
+[source,sh]
+----
+echo 'deb http://download.opensuse.org/repositories/home:/cdhermann:/wusel/Debian_13/ /' \
+  | sudo tee /etc/apt/sources.list.d/home:cdhermann:wusel.list
+curl -fsSL https://download.opensuse.org/repositories/home:cdhermann:wusel/Debian_13/Release.key \
+  | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_cdhermann_wusel.gpg > /dev/null
+sudo apt update && sudo apt install wusel
+----
+
+Anything else — Arch, an older Ubuntu, a distribution not listed —
+xref:how-to/install-a-package.adoc[Install a package] has the remaining routes.
 
 That is the only step where your distribution matters. Everything below is the
 same everywhere.

--- a/documentation/modules/ROOT/pages/tutorials/on-gnome.adoc
+++ b/documentation/modules/ROOT/pages/tutorials/on-gnome.adoc
@@ -44,23 +44,38 @@ changes.
 
 == Step 1 — Install the package
 
-Download the file for your distribution and architecture from the
-https://github.com/itbh-at/wusel/releases/latest[latest release]. Then, for an
-RPM-based distribution such as Fedora:
+Wusel is published as a signed repository, so your package manager installs it
+and keeps it updated like anything else. Run the block for your distribution.
+
+Fedora:
 
 [source,sh]
 ----
-sudo dnf install ./wusel-*.rpm
+sudo dnf config-manager addrepo --from-repofile=https://download.opensuse.org/repositories/home:/cdhermann:/wusel/Fedora_44/home:cdhermann:wusel.repo
+sudo dnf install wusel
 ----
 
-For a Debian-based one such as Debian or Ubuntu:
+openSUSE Tumbleweed:
 
 [source,sh]
 ----
-sudo apt install ./wusel_*.deb
+sudo zypper addrepo https://download.opensuse.org/repositories/home:/cdhermann:/wusel/openSUSE_Tumbleweed/home:cdhermann:wusel.repo
+sudo zypper install wusel
 ----
 
-On Arch, build the recipe from the repository — `cd wusel/packaging/aur && makepkg -si`.
+Debian 13 or Ubuntu 26.04 — substitute `xUbuntu_26.04` for `Debian_13` on Ubuntu:
+
+[source,sh]
+----
+echo 'deb http://download.opensuse.org/repositories/home:/cdhermann:/wusel/Debian_13/ /' \
+  | sudo tee /etc/apt/sources.list.d/home:cdhermann:wusel.list
+curl -fsSL https://download.opensuse.org/repositories/home:cdhermann:wusel/Debian_13/Release.key \
+  | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_cdhermann_wusel.gpg > /dev/null
+sudo apt update && sudo apt install wusel
+----
+
+Anything else — Arch, an older Ubuntu, a distribution not listed —
+xref:how-to/install-a-package.adoc[Install a package] has the remaining routes.
 
 That is the only step where your distribution matters. Everything below is the
 same everywhere.

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,10 @@
+wusel (0.3.1) unstable; urgency=medium
+
+  * Keep the vendored Cargo.toml.orig manifests through dh_clean, without which
+    the offline build fails its checksum verification.
+
+ -- Christoph D. Hermann <christoph.hermann@itbh.at>  Wed, 26 Aug 2026 12:40:00 +0200
+
 wusel (0.3.0) unstable; urgency=medium
 
   * Packages for Debian/Ubuntu and Arch alongside the Fedora RPM, built from

--- a/packaging/deb/debian/rules
+++ b/packaging/deb/debian/rules
@@ -55,3 +55,19 @@ override_dh_auto_install:
 
 override_dh_dwz:
 	# No split debug info to process — see wusel.spec's debug_package note.
+
+# dh_clean deletes `*.orig` — patch leftovers, normally. `cargo vendor` writes
+# one per crate whose manifest it rewrites (289 of them here) and lists each in
+# that crate's .cargo-checksum.json, so removing them makes the offline build
+# fail on "failed to calculate checksum of vendor/<crate>/Cargo.toml.orig".
+#
+# It bites in the *source* build, before anything is compiled: building the
+# source package runs `debian/rules clean` first, so the tarball was packed
+# without them and every rebuild from it was doomed — including the one the
+# Open Build Service does.
+#
+# Same class of bug as the tar-ignore list in debian/source/options, and the
+# same lesson: a vendored tree is source, not build output, and the tools that
+# tidy build output must be told so one at a time.
+override_dh_clean:
+	dh_clean -X.orig

--- a/packaging/rpm/wusel.spec
+++ b/packaging/rpm/wusel.spec
@@ -171,6 +171,10 @@ fi
 # with no system-wide preset to apply; each user enables their own instance.
 
 %changelog
+* Wed Aug 26 2026 Christoph D. Hermann <christoph.hermann@itbh.at> - 0.3.1-1
+- The Debian and Ubuntu packages build again; the documentation installs from
+  the signed repository rather than from a downloaded file.
+
 * Tue Aug 25 2026 Christoph D. Hermann <christoph.hermann@itbh.at> - 0.3.0-1
 - Debian/Ubuntu and Arch packages join the Fedora RPM, built from the same
   recipes and published through the Open Build Service.


### PR DESCRIPTION
`dh_clean` removes `*.orig`, and `cargo vendor` writes one per crate whose
manifest it rewrites — 289 of them — each listed in that crate's checksum
manifest. Building the source package runs `clean` first, so the tarball was
packed without them and every rebuild from it failed on "failed to calculate
checksum of vendor/<crate>/Cargo.toml.orig". The RPM was unaffected, which is
why 0.3.0 shipped with the Debian and Ubuntu packages quietly broken.

The documentation moves onto the signed repository the build service publishes:
one section per package family, an explicit account of how updates arrive on
each distribution, and the single files attached to a release demoted to the
fallback they now are — for machines that cannot add a repository, and for
distributions the build service does not target.