### PR TITLE
docs(site): serve from wusel.itbh.at, and redirect the URLs the restructure broke

### DIFF
--- a/documentation/antora-playbook-site.yml
+++ b/documentation/antora-playbook-site.yml
@@ -11,6 +11,10 @@
 site:
   title: Wusel
   start_page: wusel::index.adoc
+  # An absolute URL is what makes Antora emit sitemap.xml at all — without it
+  # there is none, and a search engine has to discover every page by following
+  # links. It also makes the canonical URL on each page absolute.
+  url: https://wusel.itbh.at
 
 content:
   sources:
@@ -34,9 +38,22 @@ runtime:
   log:
     format: json
 
+urls:
+  # The Diátaxis restructure moved every page into its section, which broke
+  # every URL a search engine had indexed. `static` makes Antora emit a small
+  # redirect page at each old address, driven by the `page-aliases` attribute on
+  # the page that replaced it — so the old links keep working and the ranking
+  # they earned follows them instead of expiring in a 404.
+  redirect_facility: static
+
 ui:
   bundle:
     url: ui-bundle
+  # Copied verbatim into the site root: the CNAME GitHub Pages needs for the
+  # custom domain (the deploy uploads this directory as the whole site, so a
+  # file added by hand in the repository settings would be gone on the next
+  # build), and robots.txt pointing at the sitemap.
+  supplemental_files: ./supplemental-ui
 
 asciidoc:
   attributes:

--- a/documentation/modules/ROOT/pages/explanation/architecture.adoc
+++ b/documentation/modules/ROOT/pages/explanation/architecture.adoc
@@ -5,6 +5,7 @@
 
 = Architecture
 :description: A platform-independent engine plus thin, interchangeable frontends — where the seam runs, and why the mount is the replaceable part.
+:page-aliases: architecture.adoc
 
 Nextcloud's official client avoids a Linux VFS because a single Qt/C++ code base
 is maintained for Windows/macOS/Linux, and Linux would need its own,

--- a/documentation/modules/ROOT/pages/explanation/concurrency.adoc
+++ b/documentation/modules/ROOT/pages/explanation/concurrency.adoc
@@ -5,6 +5,7 @@
 
 = Concurrency: getting off the single dispatch thread
 :description: Why one thread deciding everything was a ceiling, and how a dependency-free state machine over a pool substrate replaced it.
+:page-aliases: concurrency.adoc
 
 NOTE: Wusel 0.1.0 served FUSE requests one at a time. This page is how that
 changed in 0.2.0, why it is shaped the way it is, and how each step is proven.

--- a/documentation/modules/ROOT/pages/explanation/desktop-integration.adoc
+++ b/documentation/modules/ROOT/pages/explanation/desktop-integration.adoc
@@ -5,6 +5,7 @@
 
 = Desktop integration
 :description: The sidebar, the emblems, the search and the notifications are four independent, fail-soft channels — what each one costs and why none of them can break the mount.
+:page-aliases: file-manager.adoc
 
 A mounted drive announces itself as a drive. Wusel is trying not to be one: the
 sidebar entry, the emblem on every file, the search that finds your Nextcloud

--- a/documentation/modules/ROOT/pages/explanation/portability.adoc
+++ b/documentation/modules/ROOT/pages/explanation/portability.adoc
@@ -5,6 +5,7 @@
 
 = Portability
 :description: What a port to another platform actually is here, which knowledge is allowed to live in a frontend, and the two gates that keep the answer checkable.
+:page-aliases: frontends.adoc
 
 NOTE: This page records an **intention**, not shipped behaviour. Only the Linux
 FUSE frontend exists — but the groundwork it argues for is now built, and the

--- a/documentation/modules/ROOT/pages/how-to/diagnose-a-problem.adoc
+++ b/documentation/modules/ROOT/pages/how-to/diagnose-a-problem.adoc
@@ -5,6 +5,7 @@
 
 = Diagnose a problem
 :description: Two commands that answer most questions, then a symptom-ordered checklist for the mount, the desktop integration, uploads and the cache.
+:page-aliases: troubleshooting.adoc
 
 Work down this page: the two commands first, then the symptom that matches
 yours. The cases are ordered by how often each has actually bitten.

--- a/documentation/modules/ROOT/pages/how-to/install-a-package.adoc
+++ b/documentation/modules/ROOT/pages/how-to/install-a-package.adoc
@@ -5,6 +5,7 @@
 
 = Install a package
 :description: Add the Wusel repository and install with your own package manager — Fedora, openSUSE, Debian, Ubuntu — or take a single file for anything else.
+:page-aliases: installation.adoc
 
 Wusel is published as a *signed repository* through the openSUSE Build Service,
 so your package manager installs it and keeps it up to date like anything else

--- a/documentation/modules/ROOT/pages/index.adoc
+++ b/documentation/modules/ROOT/pages/index.adoc
@@ -5,6 +5,7 @@
 
 = Wusel
 :description: Wusel is a virtual file system for Nextcloud on Linux — your files appear in a folder, and are fetched only when you open them.
+:page-aliases: rust-learning-path.adoc
 
 image::wusel-logo.png[Wusel,140,role="right"]
 

--- a/documentation/modules/ROOT/pages/project/changelog.adoc
+++ b/documentation/modules/ROOT/pages/project/changelog.adoc
@@ -5,6 +5,7 @@
 
 = Changelog
 :description: What changed in each release.
+:page-aliases: changelog.adoc
 
 User-facing changes, newest first. This page and the RPM's `%changelog`
 (`packaging/rpm/wusel.spec`) describe the same releases and must stay in step —

--- a/documentation/modules/ROOT/pages/project/contributing.adoc
+++ b/documentation/modules/ROOT/pages/project/contributing.adoc
@@ -5,6 +5,7 @@
 
 = Contributing
 :description: How to report a bug, propose a change, and get a patch merged.
+:page-aliases: contributing.adoc
 
 Wusel is developed by https://itbh.at/[*IT Beratung Hermann GmbH (ITBH)*] and is
 open under Apache-2.0. Contributions are welcome — on a simple, honest basis.

--- a/documentation/modules/ROOT/pages/project/licence.adoc
+++ b/documentation/modules/ROOT/pages/project/licence.adoc
@@ -5,6 +5,7 @@
 
 = Licence and what it means for you
 :description: Apache-2.0, who develops and sells Wusel, what is free, what is commercial, and why the split is drawn where it is.
+:page-aliases: distribution.adoc
 
 This page states plainly who is behind Wusel, what is free, and where money is
 involved. We would rather be upfront about the commercial side than pretend it

--- a/documentation/modules/ROOT/pages/project/roadmap.adoc
+++ b/documentation/modules/ROOT/pages/project/roadmap.adoc
@@ -5,6 +5,7 @@
 
 = Roadmap
 :description: What is planned but not built: near-term refinements first, then the larger pieces.
+:page-aliases: roadmap.adoc
 
 What Wusel already does is described throughout this site — start at
 xref:index.adoc[the overview], or at

--- a/documentation/modules/ROOT/pages/reference/limitations.adoc
+++ b/documentation/modules/ROOT/pages/reference/limitations.adoc
@@ -5,6 +5,7 @@
 
 = Known limitations
 :description: Behaviour that is deliberate but surprising: what it looks like, why it is that way, and what to do about it.
+:page-aliases: known-limitations.adoc
 
 Behaviour that is understood, reproducible and *not* fixed yet. Every entry says
 what you see, why the software behaves that way, and what removing the

--- a/documentation/modules/ROOT/pages/reference/operation-scripts.adoc
+++ b/documentation/modules/ROOT/pages/reference/operation-scripts.adoc
@@ -5,6 +5,7 @@
 
 = Operation scripts
 :description: Which filesystem callback becomes which intent, and the state-machine script each intent runs.
+:page-aliases: fsm-scripts.adoc
 
 NOTE: These scripts are **built and running**, released in 0.2.0. Wusel 0.1.0
 ran every callback as a straight blocking function on one dispatch thread. This

--- a/documentation/modules/ROOT/pages/tutorials/on-gnome.adoc
+++ b/documentation/modules/ROOT/pages/tutorials/on-gnome.adoc
@@ -5,6 +5,7 @@
 
 = Your Nextcloud files as a folder — on GNOME
 :description: Set up the Wusel client on a GNOME desktop so the files in your Nextcloud appear as an ordinary folder, with sidebar entry, per-file emblems and Shell search.
+:page-aliases: trying-it-out.adoc, tutorials/your-nextcloud-as-a-folder.adoc
 
 Wusel is a *client*. You install it on the machine that should see the files,
 and it makes what lives in your Nextcloud appear there as an ordinary folder —

--- a/documentation/modules/ROOT/pages/tutorials/set-up-a-development-environment.adoc
+++ b/documentation/modules/ROOT/pages/tutorials/set-up-a-development-environment.adoc
@@ -5,6 +5,7 @@
 
 = Set up a Wusel development environment
 :description: Work on the Wusel client itself: from a fresh clone to a running build, a passing test suite and a live FUSE mount against the mock server — on Linux.
+:page-aliases: development.adoc
 
 This one is for people who want to *change Wusel's own code*. If you only want
 to use it — to get your Nextcloud files as a folder — you want

--- a/documentation/supplemental-ui/CNAME
+++ b/documentation/supplemental-ui/CNAME
@@ -1,0 +1,1 @@
+wusel.itbh.at

--- a/documentation/supplemental-ui/robots.txt
+++ b/documentation/supplemental-ui/robots.txt
@@ -1,0 +1,5 @@
+# Wusel documentation — https://wusel.itbh.at/
+User-agent: *
+Allow: /
+
+Sitemap: https://wusel.itbh.at/sitemap.xml

--- a/documentation/supplemental-ui/ui.yml
+++ b/documentation/supplemental-ui/ui.yml
@@ -1,0 +1,7 @@
+# Files listed here are written to the *site root* rather than under the UI
+# output directory. Both have to be there: GitHub Pages reads CNAME to learn
+# which custom domain serves this artifact, and robots.txt points crawlers at
+# the sitemap.
+static_files:
+  - CNAME
+  - robots.txt


### PR DESCRIPTION
Moving every page into its Diátaxis section turned every indexed URL into a
404, because Antora emits no redirects unless asked. A `page-aliases` attribute
on each successor, plus `redirect_facility: static`, now puts a redirect page at
all sixteen old addresses — each carrying a canonical link to its replacement.

Three things were missing besides: `site.url`, which is what makes Antora emit a
sitemap at all; a robots.txt; and the CNAME that tells GitHub Pages which custom
domain serves this artifact. All three come from the build, because the deploy
uploads the built site as the whole thing.