### PR TITLE
docs: link the documentation's own domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ FUSE only makes the files appear; on top of it sits a full GNOME desktop
 integration (sidebar, emblems, notifications, Shell search). Native macOS
 (File Provider) and Windows (Cloud Filter) frontends remain planned.
 
-**Documentation: <https://itbh-at.github.io/wusel/>**
+**Documentation: <https://wusel.itbh.at/>**
 
 ## Architecture in one sentence
 
@@ -33,7 +33,7 @@ Details: [Architecture](documentation/modules/ROOT/pages/explanation/architectur
 Order of work: [Roadmap](documentation/modules/ROOT/pages/project/roadmap.adoc). The
 docs are an [Antora](https://antora.org) component under
 [`documentation/`](documentation/), published to
-<https://itbh-at.github.io/wusel/> on every push to `main` (build locally:
+<https://wusel.itbh.at/> on every push to `main` (build locally:
 `./documentation/build.sh`, live: `./documentation/build.sh watch`).
 
 ## Install

--- a/documentation/modules/ROOT/pages/project/contributing.adoc
+++ b/documentation/modules/ROOT/pages/project/contributing.adoc
@@ -98,7 +98,7 @@ checkout — there is no separate CI script to keep in sync.
 | *Docs* (`pages.yml`)
 | every push to `main` and every pull request
 | Builds this Antora site; pushes to `main` also publish it to GitHub Pages at
-  https://itbh-at.github.io/wusel/[itbh-at.github.io/wusel]. Pull requests build
+  https://wusel.itbh.at/[wusel.itbh.at]. Pull requests build
   only, as validation.
 
 | *Release* (`release.yml`)


### PR DESCRIPTION
The site is served from wusel.itbh.at; the README and the contributing page
still sent readers through a redirect at the old address.