### PR TITLE
docs: link the product page from the documentation and the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ FUSE only makes the files appear; on top of it sits a full GNOME desktop
 integration (sidebar, emblems, notifications, Shell search). Native macOS
 (File Provider) and Windows (Cloud Filter) frontends remain planned.
 
-**Documentation: <https://wusel.itbh.at/>**
+**Documentation: <https://wusel.itbh.at/>** ·
+**Product page: <https://itbh.at/en/wusel/>**
 
 ## Architecture in one sentence
 

--- a/documentation/modules/ROOT/pages/index.adoc
+++ b/documentation/modules/ROOT/pages/index.adoc
@@ -76,3 +76,7 @@ icon. Fewer moving parts, and an experience that feels native because it is.
 
 Native frontends for macOS (File Provider) and Windows (Cloud Filter) are
 planned but not built; see the xref:project/roadmap.adoc[roadmap].
+
+Wusel is built by https://itbh.at/en/wusel/[IT Beratung Hermann], who also offer
+commercial support for it. The source is the whole product and always will be —
+xref:project/licence.adoc[Licence] says where the line runs.

--- a/documentation/modules/ROOT/pages/project/licence.adoc
+++ b/documentation/modules/ROOT/pages/project/licence.adoc
@@ -27,8 +27,9 @@ Nextcloud's own server (AGPL-3.0) or desktop client (GPL-2.0-or-later).
 
 == Who is behind it
 
-* https://itbh.at/[*IT Beratung Hermann GmbH (ITBH)*] develops `wusel` and
-  holds the copyright and the product brand.
+* https://itbh.at/en/wusel/[*IT Beratung Hermann GmbH (ITBH)*] develops
+  `wusel` and holds the copyright and the product brand. The product page also
+  carries the commercial-support offering.
 * https://ke-online.at/[*KE-Online FlexCo*] distributes the commercial store
   builds and provides commercial support.
 


### PR DESCRIPTION
Neither mentioned it. The documentation named the company twice and pointed at
its home page; the README did not mention it at all — so a reader arriving from
a search had no route to who builds this, or to whether commercial support
exists.