### PR TITLE
fix(core): surface stuck uploads, and let push recover on its own

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "wusel"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "wusel-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bytes",
  "diffy",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "wusel-desktop"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "tracing",
  "wusel-core",
@@ -2753,11 +2753,11 @@ dependencies = [
 
 [[package]]
 name = "wusel-fsm"
-version = "0.3.1"
+version = "0.3.2"
 
 [[package]]
 name = "wusel-fuse"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "fuser",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "wusel-mock"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "reqwest",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 # simply does not get it, so a new field added below is only live once the crate
 # manifests reference it.
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 # Distro packaging (RPM/DEB from source, COPR/OBS/AUR) needs this to be the true
 # floor, not "whatever mise happened to pin at scaffold time" (it was 1.97, an

--- a/crates/wusel-core/src/push.rs
+++ b/crates/wusel-core/src/push.rs
@@ -194,9 +194,13 @@ const MAX_BACKOFF_SECS: u64 = 30;
 /// using notices that the server went away — and, more usefully, that it came
 /// back — and can say so (see [`crate::health`]).
 ///
-/// A server that *answers* is not retried: a rejected password, or an OCS
-/// endpoint that is simply not there, will answer the same way forever, and TTL
-/// revalidation is the correct fallback for it.
+/// A server that answers with a *settled* client refusal — a rejected password
+/// (`401`), or an OCS endpoint that is simply not there (`404`) — will answer the
+/// same way forever, so it is not retried and TTL revalidation is the correct
+/// fallback. A transient answer, though, *is* retried (see
+/// [`retriable_for_discovery`]): transport blips, `408`/`429`/`5xx`, and a `403`,
+/// which on the public capabilities endpoint is a proxy/CSRF-window or
+/// brute-force-throttle artifact rather than a real refusal.
 async fn discover(
     client: &reqwest::Client,
     server: &str,
@@ -217,20 +221,39 @@ async fn discover(
                 }
                 return Some(info);
             }
-            Err(e) if e.is_transport() => {
-                if let Some(health) = health {
-                    health.failed(&e);
+            Err(e) if retriable_for_discovery(&e) => {
+                // A transport failure is also a reachability event; a bad status
+                // is the server answering, so it is not.
+                if e.is_transport() {
+                    if let Some(health) = health {
+                        health.failed(&e);
+                    }
                 }
-                tracing::warn!(%e, "notify_push: the server cannot be reached — retrying in {backoff}s");
+                tracing::warn!(%e, "notify_push: capability lookup failed — retrying in {backoff}s");
                 tokio::time::sleep(Duration::from_secs(backoff)).await;
                 backoff = (backoff * 2).min(MAX_BACKOFF_SECS);
             }
             Err(e) => {
-                tracing::warn!(%e, "notify_push: capability lookup failed — relying on TTL");
+                tracing::warn!(%e, "notify_push: capability lookup refused — relying on TTL");
                 return None;
             }
         }
     }
+}
+
+/// Whether a failed capability lookup is worth retrying rather than giving up on
+/// notify_push for the whole session.
+///
+/// Retry transport blips and transient HTTP (`408`/`429`/`5xx`) — and, unlike
+/// [`Error::is_permanent`], also **403**: the capabilities endpoint is public, so
+/// a 403 there is a proxy/CSRF-window or brute-force-throttle artifact during a
+/// connection wobble, not a real permission denial. Treating it as final (the
+/// old behaviour) stranded instant push on TTL until the next restart, even
+/// though the very next request would have succeeded. A genuinely settled client
+/// refusal (`401` bad credentials, `404` no such endpoint, other `4xx`) still
+/// gives up — TTL revalidation is the right fallback there.
+fn retriable_for_discovery(e: &Error) -> bool {
+    e.is_transport() || !e.is_permanent() || matches!(e, Error::HttpStatus { status: 403, .. })
 }
 
 /// One connection: authenticate, then translate events into invalidations until
@@ -335,6 +358,34 @@ fn now_secs() -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn http(status: u16) -> Error {
+        Error::HttpStatus {
+            status,
+            message: "test".into(),
+        }
+    }
+
+    #[test]
+    fn discovery_retries_transient_failures_including_403() {
+        // Retriable: a transport blip, transient HTTP, and a 403 (proxy/CSRF/
+        // throttle artifact on the public capabilities endpoint).
+        assert!(retriable_for_discovery(&Error::Http(
+            "connection reset".into()
+        )));
+        assert!(retriable_for_discovery(&http(500)));
+        assert!(retriable_for_discovery(&http(503)));
+        assert!(retriable_for_discovery(&http(429)));
+        assert!(retriable_for_discovery(&http(408)));
+        assert!(
+            retriable_for_discovery(&http(403)),
+            "a 403 during a wobble must not strand push on TTL until restart"
+        );
+        // Settled client refusals: give up, TTL is the right fallback.
+        assert!(!retriable_for_discovery(&http(401)));
+        assert!(!retriable_for_discovery(&http(404)));
+        assert!(!retriable_for_discovery(&http(400)));
+    }
 
     #[test]
     fn classifies_events() {

--- a/crates/wusel-core/src/runtime.rs
+++ b/crates/wusel-core/src/runtime.rs
@@ -657,8 +657,25 @@ fn uploader_loop(to_fsm: &Sender<Event>, db_path: &std::path::Path, shutdown: &R
     loop {
         // A fresh connection per pass, like the syncer's: cheap, and it never
         // holds the database while it waits.
-        let owed = match StateDb::open_existing(db_path).and_then(|db| db.pending_uploads()) {
-            Ok(pending) => {
+        let owed = match StateDb::open_existing(db_path) {
+            Ok(db) => {
+                // Heal ghost uploads (the node is gone) before resuming the rest,
+                // so a database written before the delete-cascade fix stops
+                // retrying them forever as no-ops. New deletes clear their own.
+                match db.remove_orphaned_uploads() {
+                    Ok(n) if n > 0 => {
+                        tracing::info!(count = n, "uploader: cleared orphaned pending uploads")
+                    }
+                    Ok(_) => {}
+                    Err(e) => tracing::debug!(%e, "uploader: orphan sweep failed"),
+                }
+                let pending = match db.pending_uploads() {
+                    Ok(pending) => pending,
+                    Err(e) => {
+                        tracing::debug!(%e, "uploader: could not read pending uploads");
+                        Vec::new()
+                    }
+                };
                 let mut owed = 0usize;
                 for p in pending {
                     // `error` records are parked for the user; only `pending`
@@ -680,7 +697,7 @@ fn uploader_loop(to_fsm: &Sender<Event>, db_path: &std::path::Path, shutdown: &R
                 owed
             }
             Err(e) => {
-                tracing::debug!(%e, "uploader: could not read pending uploads");
+                tracing::debug!(%e, "uploader: could not open the state database");
                 0
             }
         };
@@ -1529,10 +1546,7 @@ impl Worker {
                 precondition,
                 mtime,
             } => self.upload(*object, *size, precondition, *mtime),
-            Job::ResolveConflict { object } => match self.resolve_conflict(*object) {
-                Ok(()) => (Completion::Done, Payload::None),
-                Err(e) => failed(job, &e),
-            },
+            Job::ResolveConflict { object } => self.resolve_conflict(*object),
             Job::HydrateBuffer { object } => match self.hydrate_buffer(*object) {
                 Ok(()) => (Completion::Done, Payload::None),
                 Err(e) => failed(job, &e),
@@ -1816,6 +1830,46 @@ impl Worker {
             .store_file(&node, &self.buffer_path(object), &etag)
     }
 
+    /// A publish that was already answered "saved" then failed on the network.
+    ///
+    /// Both server-touching halves of a publish reach here — the direct `PUT`
+    /// (`upload`) and the 412 sub-script (`resolve_conflict`) — so the decision
+    /// is made once and identically:
+    ///
+    /// - **permanent** (a `4xx` that is not `408`/`429`, or `507 Insufficient
+    ///   Storage` — wrong permissions, a name conflict, no quota): tell the user
+    ///   and return [`Failure::Permanent`]. The script's `past_commit` handling
+    ///   (see `wusel-fsm`'s `advance`) then routes it to `SetUploadError`, which
+    ///   parks the record so it is not retried and keeps the buffer so the edit
+    ///   can still be resolved.
+    /// - **transient** (a `5xx`, a timeout, a dropped connection): stay silent —
+    ///   a notice on every attempt is noise — and return [`Failure::Io`], which
+    ///   leaves the record `pending` for the uploader to try again.
+    ///
+    /// The distinction used to live only in the direct `PUT` step; a permanent
+    /// refusal *inside* conflict resolution was flattened to `Failure::Io` by
+    /// `failed_at` and retried forever, and the user was never told. Sharing the
+    /// decision closes that gap for every frontend.
+    fn publish_failed(
+        desktop: &dyn crate::desktop::Desktop,
+        path: &str,
+        e: &crate::Error,
+    ) -> (Completion, Payload) {
+        // The edit is only local now — data at risk — so the tray reflects it.
+        desktop.set_status(crate::desktop::Status::Error);
+        if e.is_permanent() {
+            desktop.notify(&crate::desktop::Notice::UploadFailed {
+                path: path.to_string(),
+                reason: e.to_string(),
+            });
+            tracing::warn!(%path, error = %e, "publish failed permanently; parked");
+            (Completion::Failed(Failure::Permanent), Payload::None)
+        } else {
+            tracing::debug!(%path, error = %e, "publish failed transiently; will retry");
+            (Completion::Failed(Failure::Io), Payload::None)
+        }
+    }
+
     /// Send the buffer to the server under the precondition the machine chose.
     ///
     /// A rejection is not an error: `Rejected` is a step outcome the script has
@@ -1873,52 +1927,39 @@ impl Worker {
             // Not an error: the sub-script resolves it, and it sets the
             // indicator back itself once the bytes are safe somewhere.
             Ok(crate::webdav::PutResult::Conflict) => (Completion::Rejected, Payload::None),
-            Err(e) => {
-                // The edit is only local, which is data at risk and worth
-                // telling the user about — the buffer is kept, so the next
-                // flush retries.
-                write.desktop.set_status(crate::desktop::Status::Error);
-                if e.is_permanent() {
-                    // No retry will fix this — tell the user and park it. The
-                    // buffer is kept, so the change is not lost and can be
-                    // resolved.
-                    write.desktop.notify(&crate::desktop::Notice::UploadFailed {
-                        path: node.path.clone(),
-                        reason: e.to_string(),
-                    });
-                    tracing::warn!(path = %node.path, error = %e, "upload failed permanently; parked");
-                    (Completion::Failed(Failure::Permanent), Payload::None)
-                } else {
-                    // Transient (a 5xx, a timeout, a dropped connection): the
-                    // uploader will retry. Do not notify on every attempt — that
-                    // is noise — and leave the change queued.
-                    tracing::debug!(path = %node.path, error = %e, "upload failed transiently; will retry");
-                    failed_at("upload", &e)
-                }
-            }
+            // A permanent refusal is parked and shown; a transient one is
+            // retried in silence — the same decision the conflict sub-script makes.
+            Err(e) => Self::publish_failed(&*write.desktop, &node.path, &e),
         }
     }
 
     /// The 412 sub-script: merge if we can, otherwise park the bytes beside the
     /// server's version. One implementation, shared with the engine's own path.
-    fn resolve_conflict(&mut self, object: ObjectId) -> crate::Result<()> {
+    fn resolve_conflict(&mut self, object: ObjectId) -> (Completion, Payload) {
         let Some(write) = self.write.clone() else {
-            return Err(crate::Error::Other("no write context".into()));
+            return failed_at("resolve-conflict", &"no write context");
         };
-        // Whichever way it resolves, the bytes end up safe — so the indicator
-        // goes back to Idle when it returns.
-        let Some(node) = self.db.node_by_inode(object.0)? else {
-            return Err(crate::Error::NotFound);
+        let node = match self.db.node_by_inode(object.0) {
+            Ok(Some(n)) => n,
+            Ok(None) => return failed_at("resolve-conflict", &"the row is gone"),
+            Err(e) => return failed_at("resolve-conflict", &e),
         };
         let path = self.buffer_path(object);
-        let size = std::fs::metadata(&path)?.len();
-        let outcome = run_conflict_resolution(&write, &mut self.db, &node, &path, size);
-        write.desktop.set_status(if outcome.is_ok() {
-            crate::desktop::Status::Idle
-        } else {
-            crate::desktop::Status::Error
-        });
-        outcome
+        let size = match std::fs::metadata(&path) {
+            Ok(m) => m.len(),
+            Err(e) => return failed_at("resolve-conflict", &e),
+        };
+        match run_conflict_resolution(&write, &mut self.db, &node, &path, size) {
+            // Whichever way it resolved, the bytes ended up safe.
+            Ok(()) => {
+                write.desktop.set_status(crate::desktop::Status::Idle);
+                (Completion::Done, Payload::None)
+            }
+            // A server write after the local commit failed. Classify it like the
+            // direct PUT: a permanent refusal is parked and the user told once, a
+            // transient one is retried — never a silent forever-loop.
+            Err(e) => Self::publish_failed(&*write.desktop, &node.path, &e),
+        }
     }
 
     /// The shareable half of the engine, or a clear error if this substrate was
@@ -2035,11 +2076,12 @@ impl Worker {
 
 #[cfg(test)]
 mod tests {
-    use super::{withdraw_write, Metered};
-    use crate::desktop::Desktop;
+    use super::{withdraw_write, Metered, Worker};
+    use crate::desktop::{Desktop, Notice, Status};
     use crate::model::is_writable;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
+    use wusel_fsm::{Completion, Failure};
 
     /// Withdrawing the write permission is what makes an outdated offline copy
     /// read-only, so it must actually leave the row non-writable — and the empty
@@ -2135,5 +2177,79 @@ mod tests {
             "a failing step must say what failed — use `failed(job, &e)` or \
              `failed_at(name, &e)`: {offenders:?}"
         );
+    }
+
+    /// Records every notice and the last status, so a decision that must *tell
+    /// the user* can be asserted without a D-Bus round-trip.
+    #[derive(Default)]
+    struct Recording {
+        notices: Mutex<Vec<Notice>>,
+        last_status: Mutex<Option<Status>>,
+    }
+    impl Desktop for Recording {
+        fn notify(&self, n: &Notice) {
+            self.notices.lock().unwrap().push(n.clone());
+        }
+        fn set_status(&self, s: Status) {
+            *self.last_status.lock().unwrap() = Some(s);
+        }
+        fn is_metered(&self) -> Option<bool> {
+            None
+        }
+    }
+
+    fn http(status: u16) -> crate::Error {
+        crate::Error::HttpStatus {
+            status,
+            message: "x".into(),
+        }
+    }
+
+    /// A permanent publish refusal is shown to the user exactly once and returns
+    /// `Permanent`, which the script routes to parking (not an endless retry).
+    #[test]
+    fn a_permanent_publish_failure_notifies_and_parks() {
+        for e in [http(403), http(507), http(409), crate::Error::Denied] {
+            let d = Recording::default();
+            let (completion, _) = Worker::publish_failed(&d, "docs/report.txt", &e);
+            assert_eq!(
+                completion,
+                Completion::Failed(Failure::Permanent),
+                "{e} must park, not retry"
+            );
+            let notices = d.notices.lock().unwrap();
+            assert_eq!(notices.len(), 1, "{e} must tell the user once");
+            assert!(
+                matches!(&notices[0], Notice::UploadFailed { path, .. } if path == "docs/report.txt"),
+                "the notice names the file: {:?}",
+                notices[0]
+            );
+            assert_eq!(*d.last_status.lock().unwrap(), Some(Status::Error));
+        }
+    }
+
+    /// A transient publish failure stays silent (a notice per attempt is noise)
+    /// and returns `Io`, which leaves the record pending for the uploader.
+    #[test]
+    fn a_transient_publish_failure_is_silent_and_retried() {
+        for e in [
+            http(500),
+            http(503),
+            http(429),
+            http(408),
+            crate::Error::Http("[connect] reset".into()),
+        ] {
+            let d = Recording::default();
+            let (completion, _) = Worker::publish_failed(&d, "docs/report.txt", &e);
+            assert_eq!(
+                completion,
+                Completion::Failed(Failure::Io),
+                "{e} must be retried, not parked"
+            );
+            assert!(
+                d.notices.lock().unwrap().is_empty(),
+                "{e} must not notify — retries would spam the user"
+            );
+        }
     }
 }

--- a/crates/wusel-core/src/state.rs
+++ b/crates/wusel-core/src/state.rs
@@ -679,6 +679,21 @@ impl StateDb {
         Ok(())
     }
 
+    /// Drop pending uploads whose node no longer exists, returning how many went.
+    ///
+    /// A removed node's upload is now cleared with the node ([`delete_subtree`]),
+    /// but a database written before that fix can still hold such ghosts — rows
+    /// the uploader retries forever with no buffer to send, showing as permanent
+    /// "waiting" uploads in `wusel status`. A periodic sweep heals them.
+    pub fn remove_orphaned_uploads(&self) -> Result<usize> {
+        let n = self.conn.execute(
+            "DELETE FROM pending_uploads
+             WHERE object_id NOT IN (SELECT inode FROM nodes)",
+            [],
+        )?;
+        Ok(n)
+    }
+
     // --- Pins ("always keep offline") ---------------------------------------
 
     /// The pins of a database written before they moved into their own file.
@@ -798,6 +813,10 @@ fn delete_subtree(tx: &rusqlite::Transaction, inode: u64) -> Result<usize> {
     }
     for ino in &to_delete {
         tx.execute("DELETE FROM nodes WHERE inode = ?1", [ino])?;
+        // A removed node owes no upload. Drop any so it cannot linger as a ghost
+        // "waiting" entry the uploader retries forever with no buffer to send
+        // (which showed up as permanent, unexplained uploads in `wusel status`).
+        tx.execute("DELETE FROM pending_uploads WHERE object_id = ?1", [ino])?;
     }
     Ok(to_delete.len())
 }
@@ -958,6 +977,52 @@ mod tests {
         assert!(db.children_loaded(ROOT_INODE).unwrap());
         let photos = db.child_by_name(ROOT_INODE, "Photos").unwrap().unwrap();
         assert!(!db.children_loaded(photos.inode).unwrap());
+    }
+
+    #[test]
+    fn deleting_a_node_clears_its_pending_upload() {
+        let mut db = StateDb::open_in_memory().unwrap();
+        db.reconcile_children(ROOT_INODE, "", &[entry("Invoice.pdf", false)])
+            .unwrap();
+        let node = db
+            .child_by_name(ROOT_INODE, "Invoice.pdf")
+            .unwrap()
+            .unwrap();
+        db.mark_pending_upload(ObjectId(node.inode), "Invoice.pdf", "e", None)
+            .unwrap();
+        assert_eq!(db.pending_uploads().unwrap().len(), 1);
+
+        // Removing the node (a server-side delete/rename) must take its owed
+        // upload with it — otherwise it lingers as a ghost "waiting" entry.
+        db.remove_subtree(node.inode).unwrap();
+        assert!(
+            db.pending_uploads().unwrap().is_empty(),
+            "a removed node must not leave a pending upload behind"
+        );
+    }
+
+    #[test]
+    fn the_orphan_sweep_clears_only_ghost_uploads() {
+        let mut db = StateDb::open_in_memory().unwrap();
+        db.reconcile_children(ROOT_INODE, "", &[entry("Live.pdf", false)])
+            .unwrap();
+        let live = db.child_by_name(ROOT_INODE, "Live.pdf").unwrap().unwrap();
+        db.mark_pending_upload(ObjectId(live.inode), "Live.pdf", "e", None)
+            .unwrap();
+        // A ghost from an older database: a pending upload whose node is gone.
+        db.mark_pending_upload(ObjectId(999_999), "Gone.pdf", "e", None)
+            .unwrap();
+        assert_eq!(db.pending_uploads().unwrap().len(), 2);
+
+        let removed = db.remove_orphaned_uploads().unwrap();
+        assert_eq!(removed, 1, "only the node-less ghost is swept");
+        let left = db.pending_uploads().unwrap();
+        assert_eq!(left.len(), 1);
+        assert_eq!(
+            left[0].object,
+            ObjectId(live.inode),
+            "the live upload stays"
+        );
     }
 
     #[test]

--- a/documentation/modules/ROOT/pages/project/changelog.adoc
+++ b/documentation/modules/ROOT/pages/project/changelog.adoc
@@ -14,6 +14,35 @@ the RPM is terse because a package changelog is, this page has room to say why.
 The format follows https://keepachangelog.com/en/1.1.0/[Keep a Changelog]; the
 project uses https://semver.org/[Semantic Versioning].
 
+== 0.3.2 — 2026-08-27
+
+=== Fixed
+
+* **A file that cannot be uploaded now says so, once, instead of retrying
+  forever in silence.** When a save hit a conflict and the server then refused
+  the merged result for good — no quota, a revoked permission — that permanent
+  refusal was mistaken for a transient one, so the upload was retried on every
+  pass and the user was never told. The file read as saved and was not on the
+  server. A permanent failure during conflict resolution is now surfaced and
+  parked exactly like a permanent failure on a direct upload — the contract
+  0.2.0 already promised, now kept in this case too.
+
+* **A deleted or renamed file no longer leaves a phantom upload behind.**
+  Removing a node dropped it from the state but left its pending-upload record,
+  which the uploader then resumed on every pass — no file, no attempt, no error
+  — so it sat in `wusel status` as a "waiting" upload that could never land or
+  clear. The record is now removed with the node, and a one-time sweep heals
+  databases that already carry such leftovers.
+
+* **A brief hiccup at start no longer costs live updates for the whole
+  session.** Discovering the `notify_push` endpoint gave up permanently on a
+  single transient error — most often a 403 from a proxy's CSRF window or a
+  throttle during a connection wobble — stranding the mount on slower TTL
+  revalidation until the next restart. Discovery now retries the same transient
+  failures the uploader does (and treats a 403 on the public capabilities
+  endpoint as transient rather than a real refusal), so instant updates resume
+  on their own once the server does.
+
 == 0.3.1 — 2026-08-26
 
 === Added

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,11 @@
+wusel (0.3.2) unstable; urgency=medium
+
+  * Surface a permanently failed upload instead of retrying it forever in
+    silence; heal phantom "waiting" uploads left by a delete or rename; and
+    let notify_push recover on its own after a transient discovery error.
+
+ -- Christoph D. Hermann <christoph.hermann@itbh.at>  Thu, 27 Aug 2026 17:00:00 +0200
+
 wusel (0.3.1) unstable; urgency=medium
 
   * Keep the vendored Cargo.toml.orig manifests through dh_clean, without which

--- a/packaging/rpm/wusel.spec
+++ b/packaging/rpm/wusel.spec
@@ -171,6 +171,11 @@ fi
 # with no system-wide preset to apply; each user enables their own instance.
 
 %changelog
+* Thu Aug 27 2026 Christoph D. Hermann <christoph.hermann@itbh.at> - 0.3.2-1
+- A permanently failed upload is now surfaced once instead of retried forever
+  in silence, phantom "waiting" uploads left by a delete or rename are cleared,
+  and notify_push recovers on its own after a transient discovery error.
+
 * Wed Aug 26 2026 Christoph D. Hermann <christoph.hermann@itbh.at> - 0.3.1-1
 - The Debian and Ubuntu packages build again; the documentation installs from
   the signed repository rather than from a downloaded file.


### PR DESCRIPTION
Three engine fixes found once wider testing put larger accounts and flakier
connections through the mount, released as 0.3.2.

A permanent server refusal during 412 conflict resolution was mistaken for a
transient one, so a save that could never land was retried forever and the
user was never told — the file read as saved and was not on the server. That
permanent failure is now surfaced and parked exactly as a permanent failure on
a direct upload is, the contract 0.2.0 already promised.

A deleted or renamed file left its pending-upload record behind, which the
uploader resumed on every pass with no node to act on — a "waiting" upload in
`wusel status` that could never clear. The record is dropped with the node, and
a one-time sweep heals databases that already carry such leftovers.

Discovering the notify_push endpoint gave up for the whole session on a single
transient error, stranding the mount on TTL revalidation until the next
restart. Discovery now retries the transient failures the uploader does, so
instant updates resume on their own once the server recovers.