### PR TITLE
feat(mount): real Nextcloud quota, a server notification hook, and doc search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,11 @@ jobs:
 
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          # Pin mise itself, not only the action: the action installs the latest
+          # mise otherwise, and a new mise (2027.x changed the npm backend's
+          # layout) breaks a build that passes on the pinned version. Same value
+          # as MISE_VERSION in the Containerfiles — one source of truth.
+          version: 2026.6.10
           install: false
       # Exactly the tools this workflow uses — rust for the cargo tasks, hawkeye
       # for headers-check, shellcheck for the script lint. The docs toolchain is

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -208,6 +208,7 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-cargo-e2e-
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          version: 2026.6.10 # pin mise; see ci.yml
           install: false
       - name: Install the pinned Rust toolchain
         run: mise install rust

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -72,14 +72,15 @@ jobs:
           fetch-tags: true
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          version: 2026.6.10 # pin mise; see ci.yml
           install: false
       # The docs are the one place that legitimately needs the node toolchain —
       # but only `antora`. watchexec and browser-sync serve `build.sh watch`
       # locally, d2 renders diagrams whose SVGs are committed, and rust/hawkeye
       # belong to the Rust workflow. Naming them keeps this job's footprint to
       # what the antora build actually uses.
-      - name: Install the pinned docs toolchain (node, antora)
-        run: mise install node "npm:antora"
+      - name: Install the pinned docs toolchain (node, antora, lunr)
+        run: mise install node "npm:antora" "npm:@antora/lunr-extension"
       - name: Build the documentation
         # `site`, not the default: the multi-version, version-selector build.
         run: mise exec -- ./documentation/build.sh site

--- a/crates/wusel-core/src/config.rs
+++ b/crates/wusel-core/src/config.rs
@@ -272,6 +272,7 @@ pub fn list_accounts() -> Vec<String> {
 /// [sync]
 /// revalidate_secs = 30   # re-list a directory older than this (no-push fallback)
 /// push_floor_secs = 5    # min interval between push-triggered re-lists of a dir
+/// quota_revalidate_secs = 60  # how long a fetched storage quota is trusted
 /// text_merge = false     # opt-in: 3-way-merge text on conflict (else a copy)
 /// refresh_pinned = "ask" # manual | ask | auto — what to do when a pinned
 ///                        # file's server copy has moved on
@@ -290,6 +291,9 @@ pub fn list_accounts() -> Vec<String> {
 /// point = "/home/you/Wusel"            # where `mount` (with no path) attaches
 /// [desktop]
 /// exclude_from_indexers = true         # default; false = allow GNOME Tracker to index
+/// notify_hook = "/etc/wusel/on-notice" # optional: run this on every user notice — the
+///                                       # escape hatch for headless boxes with no D-Bus
+///                                       # session (see the notify-hook how-to)
 /// ```
 #[derive(Debug, Clone)]
 pub struct Settings {
@@ -300,6 +304,12 @@ pub struct Settings {
     /// hammering the same directory) into at most one PROPFIND per window, while
     /// still reacting to real changes within a few seconds.
     pub push_floor_secs: u64,
+    /// How long a fetched Nextcloud storage quota (`statfs`'s notion of total
+    /// / free space) is trusted before it is refreshed. Deliberately coarser
+    /// than `revalidate_secs`: quota changes far less often than a directory's
+    /// contents, and a refresh is a request some applications trigger before
+    /// every save.
+    pub quota_revalidate_secs: u64,
     pub cache_max_bytes: Option<u64>,
     pub cache_max_age_secs: Option<u64>,
     pub tls: TlsSettings,
@@ -353,6 +363,13 @@ pub struct Settings {
     /// storm. Set `false` to opt back in to indexing. (KDE Baloo ignores markers
     /// — it needs a config-based exclude, a later addition.)
     pub exclude_from_indexers: bool,
+    /// A script run on every [`crate::desktop::Notice`], in addition to the
+    /// platform notification. **Off by default.** The escape hatch for a
+    /// headless box with no D-Bus session (a server, a container): the notice
+    /// still reaches something — journal, mail, a webhook — via whatever the
+    /// script does with it. See [`crate::desktop::Notice::to_json`] for what it
+    /// receives.
+    pub notify_hook: Option<PathBuf>,
 }
 
 /// The default dispatch-thread count: the machine's parallelism, floored at 4 so
@@ -371,6 +388,7 @@ impl Default for Settings {
         Self {
             revalidate_secs: 30,
             push_floor_secs: 5,
+            quota_revalidate_secs: 60,
             cache_max_bytes: Some(5 * 1024 * 1024 * 1024), // 5 GiB
             cache_max_age_secs: None,
             tls: TlsSettings::default(),
@@ -387,6 +405,7 @@ impl Default for Settings {
                 .collect(),
             auth_keyring: true,
             exclude_from_indexers: true,
+            notify_hook: None,
         }
     }
 }
@@ -625,6 +644,7 @@ impl UploadMode {
 struct RawSync {
     revalidate_secs: Option<u64>,
     push_floor_secs: Option<u64>,
+    quota_revalidate_secs: Option<u64>,
     text_merge: Option<bool>,
     refresh_pinned: Option<String>,
     open_pinned: Option<String>,
@@ -649,6 +669,7 @@ struct RawAuth {
 #[derive(serde::Deserialize, Default)]
 struct RawDesktop {
     exclude_from_indexers: Option<bool>,
+    notify_hook: Option<String>,
 }
 
 fn parse_settings(text: &str) -> crate::Result<Settings> {
@@ -660,6 +681,9 @@ fn parse_settings(text: &str) -> crate::Result<Settings> {
     }
     if let Some(v) = raw.sync.push_floor_secs {
         s.push_floor_secs = v;
+    }
+    if let Some(v) = raw.sync.quota_revalidate_secs {
+        s.quota_revalidate_secs = v;
     }
     if let Some(v) = raw.sync.ignore_patterns {
         s.ignore_patterns = v; // an explicit list REPLACES the built-in default
@@ -743,6 +767,11 @@ fn parse_settings(text: &str) -> crate::Result<Settings> {
         s.dispatch_threads = n.clamp(1, 16);
     }
     s.exclude_from_indexers = raw.desktop.exclude_from_indexers.unwrap_or(true);
+    s.notify_hook = raw
+        .desktop
+        .notify_hook
+        .filter(|p| !p.is_empty())
+        .map(|p| expand_tilde(&p));
     Ok(s)
 }
 
@@ -876,10 +905,17 @@ mod tests {
     }
 
     #[test]
+    fn parses_quota_revalidate_secs() {
+        let s = parse_settings("[sync]\nquota_revalidate_secs = 120\n").unwrap();
+        assert_eq!(s.quota_revalidate_secs, 120);
+    }
+
+    #[test]
     fn empty_config_uses_defaults() {
         let s = parse_settings("").unwrap();
         assert_eq!(s.revalidate_secs, 30);
         assert_eq!(s.push_floor_secs, 5);
+        assert_eq!(s.quota_revalidate_secs, 60);
         assert!(s.cache_max_bytes.is_some());
         assert_eq!(s.cache_max_age_secs, None);
         // TLS defaults: verify against the OS store, no custom CA.
@@ -901,6 +937,19 @@ mod tests {
     fn desktop_indexing_can_be_opted_back_in() {
         let s = parse_settings("[desktop]\nexclude_from_indexers = false\n").unwrap();
         assert!(!s.exclude_from_indexers);
+    }
+
+    #[test]
+    fn notify_hook_is_off_by_default_and_parses_and_expands_tilde() {
+        assert_eq!(parse_settings("").unwrap().notify_hook, None);
+        let s = parse_settings("[desktop]\nnotify_hook = \"/etc/wusel/on-notice\"\n").unwrap();
+        assert_eq!(
+            s.notify_hook.as_deref(),
+            Some(std::path::Path::new("/etc/wusel/on-notice"))
+        );
+        // Empty string means "not set", same as every other optional path here.
+        let s = parse_settings("[desktop]\nnotify_hook = \"\"\n").unwrap();
+        assert_eq!(s.notify_hook, None);
     }
 
     #[test]

--- a/crates/wusel-core/src/desktop.rs
+++ b/crates/wusel-core/src/desktop.rs
@@ -102,6 +102,58 @@ impl Notice {
             Notice::UploadFailed { .. } | Notice::ConnectionLost { .. } => Severity::Error,
         }
     }
+
+    /// Stable, unlocalized identifier for this notice's kind — the `"kind"` field
+    /// in [`Notice::to_json`]. **A public contract** — keep these strings stable,
+    /// like [`FileState::as_xattr`](crate::provider::FileState::as_xattr): a
+    /// notify-hook script may already be matching on them.
+    fn kind(&self) -> &'static str {
+        match self {
+            Notice::ConflictCopy { .. } => "conflict-copy",
+            Notice::UploadFailed { .. } => "upload-failed",
+            Notice::ConnectionLost { .. } => "connection-lost",
+            Notice::PinnedOutOfDate { .. } => "pinned-out-of-date",
+            Notice::StaleCopyServed { .. } => "stale-copy-served",
+            Notice::ConnectionRestored { .. } => "connection-restored",
+        }
+    }
+
+    /// The raw, **unlocalized** payload — `kind`, `severity`, and this notice's
+    /// own fields as JSON. For the notify-hook's `WUSEL_NOTICE_JSON`: a script
+    /// that wants to act on a specific kind of notice (not just forward the
+    /// human sentence) reads this instead of parsing [`Notice::localize`]'s
+    /// `Message`, which changes with the user's language and wording.
+    pub fn to_json(&self) -> serde_json::Value {
+        let mut fields = match self {
+            Notice::ConflictCopy { path, copy } => {
+                serde_json::json!({ "path": path, "copy": copy })
+            }
+            Notice::UploadFailed { path, reason } => {
+                serde_json::json!({ "path": path, "reason": reason })
+            }
+            Notice::ConnectionLost { server } => serde_json::json!({ "server": server }),
+            Notice::PinnedOutOfDate { count, first } => {
+                serde_json::json!({ "count": count, "first": first })
+            }
+            Notice::StaleCopyServed { path, reason } => serde_json::json!({
+                "path": path,
+                "reason": match reason {
+                    Stale::Unreachable => "unreachable",
+                    Stale::ByChoice => "by-choice",
+                },
+            }),
+            Notice::ConnectionRestored { server } => serde_json::json!({ "server": server }),
+        };
+        // `fields` is always an object literal from the arms above, so indexing
+        // it to add two more members cannot panic.
+        fields["kind"] = serde_json::json!(self.kind());
+        fields["severity"] = serde_json::json!(match self.severity() {
+            Severity::Success => "success",
+            Severity::Warning => "warning",
+            Severity::Error => "error",
+        });
+        fields
+    }
 }
 
 /// Why an outdated copy was served.
@@ -421,5 +473,45 @@ mod tests {
             Notice::ConnectionLost { server: "x".into() }.severity(),
             Severity::Error
         );
+    }
+
+    #[test]
+    fn to_json_carries_kind_severity_and_the_raw_fields() {
+        let v = conflict().to_json();
+        assert_eq!(v["kind"], "conflict-copy");
+        assert_eq!(v["severity"], "warning");
+        assert_eq!(v["path"], "Docs/plan.md");
+        assert_eq!(v["copy"], "Docs/plan (conflicted copy 1700).md");
+    }
+
+    #[test]
+    fn to_json_is_unaffected_by_locale() {
+        // Unlike `localize`, `to_json` never translates — a script matching on
+        // `kind` must not have to handle every language.
+        let en = conflict().to_json();
+        assert_eq!(en["kind"], conflict().to_json()["kind"]);
+        assert!(!en["kind"].as_str().unwrap().is_empty());
+        // Sanity: every variant gets a distinct, non-empty kind.
+        let kinds: std::collections::HashSet<_> = [
+            conflict(),
+            Notice::UploadFailed {
+                path: "x".into(),
+                reason: "y".into(),
+            },
+            Notice::ConnectionLost { server: "x".into() },
+            Notice::ConnectionRestored { server: "x".into() },
+            Notice::PinnedOutOfDate {
+                count: 1,
+                first: "x".into(),
+            },
+            Notice::StaleCopyServed {
+                path: "x".into(),
+                reason: Stale::Unreachable,
+            },
+        ]
+        .iter()
+        .map(|n| n.to_json()["kind"].as_str().unwrap().to_string())
+        .collect();
+        assert_eq!(kinds.len(), 6, "every variant must have a distinct kind");
     }
 }

--- a/crates/wusel-core/src/model.rs
+++ b/crates/wusel-core/src/model.rs
@@ -23,6 +23,22 @@ pub struct RemoteEntry {
     pub permissions: String,
 }
 
+/// The account's storage quota, from a WebDAV `PROPFIND` on the account root
+/// (`quota-used-bytes` / `quota-available-bytes`) — the same properties the
+/// official client reads for its storage bar.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Quota {
+    /// Bytes already used.
+    pub used: u64,
+    /// Bytes still free, or `None` if the server did not report a usable
+    /// number. Nextcloud encodes "unlimited" and "quota not yet computed" as
+    /// negative values rather than omitting the property, and a negative
+    /// value fails to parse as a `u64` — which collapses both of those (and
+    /// anything else non-numeric) into "we don't actually know", rather than
+    /// risking a wrong guess at which sentinel means what.
+    pub available: Option<u64>,
+}
+
 /// The last path segment of a server-relative path — a child's own name.
 ///
 /// One definition for the whole crate: state and provider both need it, and both

--- a/crates/wusel-core/src/provider.rs
+++ b/crates/wusel-core/src/provider.rs
@@ -144,6 +144,9 @@ pub struct Provider {
     revalidate_secs: u64,
     /// Rate-limit for push-triggered re-lists (see [`crate::config::Settings`]).
     push_floor_secs: u64,
+    /// How long a fetched storage quota is trusted before `statfs` triggers a
+    /// refresh. See [`crate::runtime::QuotaCache`].
+    quota_revalidate_secs: u64,
     /// Opt-in: expose synthetic desktop-indexer exclusion markers at the mount
     /// root (a frontend reads this; see [`Self::exclude_from_indexers`]).
     exclude_from_indexers: bool,
@@ -1077,6 +1080,7 @@ impl Provider {
             content,
             revalidate_secs,
             push_floor_secs: settings.push_floor_secs,
+            quota_revalidate_secs: settings.quota_revalidate_secs,
             exclude_from_indexers: settings.exclude_from_indexers,
             invalidate_after: Arc::new(AtomicI64::new(0)),
             scratch_dir,
@@ -1211,6 +1215,11 @@ impl Provider {
             invalidate_after: Arc::clone(&self.invalidate_after),
             async_upload: self.async_upload,
             write: Some(self.write_context()),
+            quota: Some(Arc::new(crate::runtime::QuotaCache::new(
+                self.dav.clone(),
+                Arc::clone(&self.rt),
+                std::time::Duration::from_secs(self.quota_revalidate_secs),
+            ))),
         }
     }
 

--- a/crates/wusel-core/src/runtime.rs
+++ b/crates/wusel-core/src/runtime.rs
@@ -231,6 +231,10 @@ pub struct Context {
     /// runtime, the desktop channel. `None` leaves the network steps unwired,
     /// which is what the substrate-level tests use.
     pub write: Option<WriteContext>,
+    /// Real storage quota for `statfs`, refreshed in the background — see
+    /// [`QuotaCache`]. `None` in the substrate-level tests, for the same
+    /// reason `write` is: there is no WebDAV client to ask.
+    pub quota: Option<Arc<QuotaCache>>,
 }
 
 /// How many threads each pool gets.
@@ -336,6 +340,123 @@ impl Metered {
     }
 }
 
+/// Real Nextcloud storage quota (used/available bytes), refreshed in the
+/// background and served from cache in between.
+///
+/// Modelled on [`Metered`], with one difference: the underlying check here is
+/// a network round-trip, not a local D-Bus call, so it must never block the
+/// caller. `snapshot` always answers immediately with whatever is cached (the
+/// zero value before the first fetch has landed) and, if that is stale,
+/// spawns a refresh on the runtime for *next* time instead of waiting for this
+/// one — `statfs` is asked before every save by some applications, and
+/// blocking that on the network is exactly the kind of FUSE-thread stall the
+/// `put_chunked` "trust the assembled file" check exists to route around
+/// elsewhere.
+pub struct QuotaCache {
+    dav: crate::webdav::WebDavClient,
+    rt: Arc<tokio::runtime::Runtime>,
+    state: Mutex<QuotaCacheState>,
+    ttl: std::time::Duration,
+}
+
+struct QuotaCacheState {
+    quota: crate::model::Quota,
+    fetched_at: Option<std::time::Instant>,
+    /// Set while a background refresh is in flight, so a burst of `statfs`
+    /// calls before it lands triggers one fetch, not one per call.
+    refreshing: bool,
+}
+
+impl QuotaCache {
+    #[must_use]
+    pub fn new(
+        dav: crate::webdav::WebDavClient,
+        rt: Arc<tokio::runtime::Runtime>,
+        ttl: std::time::Duration,
+    ) -> Self {
+        Self {
+            dav,
+            rt,
+            state: Mutex::new(QuotaCacheState {
+                quota: crate::model::Quota::default(),
+                fetched_at: None,
+                refreshing: false,
+            }),
+            ttl,
+        }
+    }
+
+    /// The best known quota right now. Never blocks: if the cache is stale (or
+    /// there is nothing cached yet) and no refresh is already running, one is
+    /// spawned on `rt` for next time; either way this returns immediately with
+    /// whatever was cached going in.
+    #[must_use]
+    pub fn snapshot(self: &Arc<Self>) -> crate::model::Quota {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let stale = state
+            .fetched_at
+            .map(|at| at.elapsed() >= self.ttl)
+            .unwrap_or(true);
+        if stale && !state.refreshing {
+            state.refreshing = true;
+            let this = Arc::clone(self);
+            self.rt.spawn(async move {
+                // Logged at `info`, in pairs (this line, then exactly one
+                // outcome line below). Silence used to be indistinguishable
+                // between "never asked", "still in flight" and "answered with
+                // something unusable" — and `statfs` showing the placeholder
+                // looks identical in all three, so a stuck quota was
+                // undiagnosable from a log without attaching a debugger.
+                tracing::info!("fetching the storage quota");
+                let result = this.dav.quota().await;
+                let mut state = this.state.lock().unwrap_or_else(|e| e.into_inner());
+                state.refreshing = false;
+                match result {
+                    Ok(quota) => {
+                        // `available: None` is a *successful* fetch the server
+                        // answered unusably (unlimited, or not yet computed) —
+                        // reported distinctly, because it leaves `statfs` on the
+                        // placeholder and would otherwise read as a failure.
+                        match quota.available {
+                            Some(available) => tracing::info!(
+                                used = quota.used,
+                                available,
+                                "storage quota updated"
+                            ),
+                            None => tracing::info!(
+                                used = quota.used,
+                                "the server reported no usable free-space figure \
+                                 (unlimited, or not yet computed) — statfs keeps \
+                                 its placeholder"
+                            ),
+                        }
+                        state.quota = quota;
+                        state.fetched_at = Some(std::time::Instant::now());
+                    }
+                    // `fetched_at` is left as it was: a failed first fetch
+                    // (`None`) retries on the very next `snapshot` rather than
+                    // sitting on the placeholder for a whole TTL, and a failed
+                    // refresh of an existing value retries on the next call
+                    // too, since that value is already past its TTL.
+                    Err(e) => {
+                        tracing::warn!(%e, "quota refresh failed; keeping the last known value");
+                    }
+                }
+            });
+        }
+        state.quota
+    }
+
+    /// Start the first fetch now, without waiting for it and without asking for
+    /// a value — for mount start-up, so the answer is usually already in by the
+    /// time anything asks (`statfs`, i.e. `df`). Without it the *first* `df`
+    /// after a mount always reports the placeholder, because that call is what
+    /// triggers the fetch it cannot wait for.
+    pub fn prime(self: &Arc<Self>) {
+        let _ = self.snapshot();
+    }
+}
+
 /// A running substrate. Dropping it stops every thread.
 pub struct Substrate {
     to_fsm: Sender<Event>,
@@ -357,6 +478,8 @@ pub struct Substrate {
     /// Dropped first on teardown, to wake the uploader out of its wait so the
     /// join below does not block for a whole retry interval.
     uploader_shutdown: Option<Sender<()>>,
+    /// See [`Context::quota`].
+    quota: Option<Arc<QuotaCache>>,
 }
 
 impl Substrate {
@@ -507,9 +630,18 @@ impl Substrate {
                 // last of them is gone.
                 done: Mutex::new(Some(done_rx)),
                 uploader_shutdown,
+                quota: ctx.quota.clone(),
             },
             answers_rx,
         ))
+    }
+
+    /// The account's real storage quota right now, or `None` if this substrate
+    /// has no WebDAV client wired up (tests) — the frontend then falls back to
+    /// its own placeholder. Never blocks on the network; see [`QuotaCache`].
+    #[must_use]
+    pub fn quota(&self) -> Option<crate::model::Quota> {
+        self.quota.as_ref().map(QuotaCache::snapshot)
     }
 
     /// A read-only snapshot of what the substrate is doing. See

--- a/crates/wusel-core/src/webdav.rs
+++ b/crates/wusel-core/src/webdav.rs
@@ -17,7 +17,7 @@ use quick_xml::events::Event;
 use quick_xml::Reader;
 use url::Url;
 
-use crate::model::RemoteEntry;
+use crate::model::{Quota, RemoteEntry};
 use crate::{Error, Result};
 
 /// Bytes per chunk for chunked upload NG. Bounds memory to one chunk regardless
@@ -246,6 +246,30 @@ impl WebDavClient {
             .into_iter()
             .next()
             .map(|e| (e.size, e.etag)))
+    }
+
+    /// The account's storage quota, via a Depth-0 `PROPFIND` on the account
+    /// root. See [`Quota`] for how an unusable (unlimited/unknown) server
+    /// answer is told apart from a real byte count.
+    pub async fn quota(&self) -> Result<Quota> {
+        const BODY: &str = r#"<?xml version="1.0"?>
+<d:propfind xmlns:d="DAV:"><d:prop><d:quota-used-bytes/><d:quota-available-bytes/></d:prop></d:propfind>"#;
+        let resp = self
+            .send(
+                self.http
+                    .request(
+                        reqwest::Method::from_bytes(b"PROPFIND").unwrap(),
+                        self.url_for("", true)?,
+                    )
+                    .basic_auth(&self.login_name, Some(&self.app_password))
+                    .header("Depth", "0")
+                    .header("Content-Type", "application/xml")
+                    .body(BODY),
+            )
+            .await?
+            .error_for_status()?;
+        let xml = resp.text().await?;
+        Ok(parse_quota(&xml))
     }
 
     /// Loads (part of) a file. `range` = (start, len) for a range GET.
@@ -880,6 +904,55 @@ fn parse_multistatus(xml: &str, base: &str) -> Result<Vec<RemoteEntry>> {
     Ok(entries)
 }
 
+/// Parses a quota `PROPFIND` response into a [`Quota`].
+///
+/// Same event-walking shape as [`parse_multistatus`], simplified: there is
+/// only ever one `<d:response>` (Depth 0), and both properties are plain text,
+/// so no per-response bookkeeping is needed. A property that is missing,
+/// empty, or holds a negative sentinel value all fall through to `Quota`'s
+/// defaults — see its docs for why that is the safe reading.
+fn parse_quota(xml: &str) -> Quota {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+
+    let mut used = 0u64;
+    let mut available = None;
+    let mut text_target: Option<bool> = None; // Some(true) = used, Some(false) = available
+
+    loop {
+        match reader.read_event() {
+            Err(_) | Ok(Event::Eof) => break,
+            Ok(Event::Start(e)) => {
+                text_target = match local_name(e.name().as_ref()) {
+                    b"quota-used-bytes" => Some(true),
+                    b"quota-available-bytes" => Some(false),
+                    _ => None,
+                };
+            }
+            Ok(Event::Text(t)) => {
+                if let Some(is_used) = text_target {
+                    // A negative number (Nextcloud's "unlimited"/"not yet
+                    // computed" sentinels) does not parse as a `u64` — which is
+                    // exactly the fallback we want, without having to guess
+                    // which negative value means what.
+                    let parsed = t.unescape().ok().and_then(|v| v.parse::<u64>().ok());
+                    if is_used {
+                        used = parsed.unwrap_or(0);
+                    } else {
+                        available = parsed;
+                    }
+                }
+            }
+            // Same reasoning as `parse_multistatus`: any element end disarms a
+            // pending text target, so an empty property never captures a
+            // sibling's text.
+            Ok(Event::End(_)) => text_target = None,
+            _ => {}
+        }
+    }
+    Quota { used, available }
+}
+
 #[derive(Clone, Copy)]
 enum Field {
     Href,
@@ -1132,6 +1205,56 @@ mod tests {
             entries[0].etag, "abc",
             "status text must not leak into the etag"
         );
+    }
+
+    #[test]
+    fn quota_parses_real_numbers() {
+        let xml = r#"<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/remote.php/dav/files/alice/</d:href>
+    <d:propstat><d:prop>
+      <d:quota-used-bytes>123456</d:quota-used-bytes>
+      <d:quota-available-bytes>987654321</d:quota-available-bytes>
+    </d:prop></d:propstat>
+  </d:response>
+</d:multistatus>"#;
+        let quota = parse_quota(xml);
+        assert_eq!(quota.used, 123_456);
+        assert_eq!(quota.available, Some(987_654_321));
+    }
+
+    #[test]
+    fn quota_treats_a_negative_available_as_unusable() {
+        // Nextcloud's "unlimited" and "not yet computed" sentinels are negative
+        // numbers, not an omitted property.
+        let xml = r#"<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/remote.php/dav/files/alice/</d:href>
+    <d:propstat><d:prop>
+      <d:quota-used-bytes>123456</d:quota-used-bytes>
+      <d:quota-available-bytes>-3</d:quota-available-bytes>
+    </d:prop></d:propstat>
+  </d:response>
+</d:multistatus>"#;
+        let quota = parse_quota(xml);
+        assert_eq!(quota.used, 123_456);
+        assert_eq!(quota.available, None);
+    }
+
+    #[test]
+    fn quota_defaults_when_the_server_has_no_such_property() {
+        let xml = r#"<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/remote.php/dav/files/alice/</d:href>
+    <d:propstat><d:prop/></d:propstat>
+  </d:response>
+</d:multistatus>"#;
+        let quota = parse_quota(xml);
+        assert_eq!(quota.used, 0);
+        assert_eq!(quota.available, None);
     }
 
     #[test]

--- a/crates/wusel-core/tests/db_concurrency.rs
+++ b/crates/wusel-core/tests/db_concurrency.rs
@@ -81,6 +81,7 @@ fn a_metadata_read_is_served_while_a_write_transaction_is_held() {
         invalidate_after: std::sync::Arc::new(std::sync::atomic::AtomicI64::new(0)),
         async_upload: true,
         write: None,
+        quota: None,
     };
     let (substrate, answers) =
         Substrate::start(&ctx, Pools::default()).expect("start the substrate");

--- a/crates/wusel-core/tests/diag_snapshot.rs
+++ b/crates/wusel-core/tests/diag_snapshot.rs
@@ -92,6 +92,7 @@ fn the_substrate_reports_a_stuck_fetch_while_the_decider_stays_responsive() {
         invalidate_after: Arc::new(std::sync::atomic::AtomicI64::new(0)),
         async_upload: true,
         write: None,
+        quota: None,
     };
     let (substrate, _answers) = Substrate::start(&ctx, Pools::default()).expect("start");
 

--- a/crates/wusel-core/tests/fetch_join.rs
+++ b/crates/wusel-core/tests/fetch_join.rs
@@ -99,6 +99,7 @@ fn a_second_reader_of_the_same_range_joins_the_transfer_in_flight() {
         invalidate_after: std::sync::Arc::new(std::sync::atomic::AtomicI64::new(0)),
         async_upload: true,
         write: None,
+        quota: None,
     };
     let (substrate, answers) = Substrate::start(&ctx, Pools::default()).expect("start");
 
@@ -209,6 +210,7 @@ fn an_abandoned_fetch_is_answered_with_an_error_and_leaves_no_slot_behind() {
         invalidate_after: std::sync::Arc::new(std::sync::atomic::AtomicI64::new(0)),
         async_upload: true,
         write: None,
+        quota: None,
     };
     let (substrate, answers) = Substrate::start(&ctx, Pools::default()).expect("start");
 

--- a/crates/wusel-core/tests/shutdown.rs
+++ b/crates/wusel-core/tests/shutdown.rs
@@ -82,6 +82,7 @@ fn stopping_does_not_wait_for_a_worker_stuck_in_a_job() {
         invalidate_after: Arc::new(std::sync::atomic::AtomicI64::new(0)),
         async_upload: true,
         write: None,
+        quota: None,
     };
     let (substrate, _answers) = Substrate::start(&ctx, Pools::default()).expect("start");
 

--- a/crates/wusel-core/tests/write_buffer.rs
+++ b/crates/wusel-core/tests/write_buffer.rs
@@ -75,6 +75,7 @@ fn bytes_written_are_read_back_from_the_buffer_not_the_server() {
         invalidate_after: std::sync::Arc::new(std::sync::atomic::AtomicI64::new(0)),
         async_upload: true,
         write: None,
+        quota: None,
     };
     let (substrate, answers) = Substrate::start(&ctx, Pools::default()).expect("start");
 
@@ -137,6 +138,7 @@ fn a_second_write_lands_after_the_first_and_keeps_its_bytes() {
         invalidate_after: std::sync::Arc::new(std::sync::atomic::AtomicI64::new(0)),
         async_upload: true,
         write: None,
+        quota: None,
     };
     let (substrate, answers) = Substrate::start(&ctx, Pools::default()).expect("start");
 

--- a/crates/wusel-desktop/Cargo.toml
+++ b/crates/wusel-desktop/Cargo.toml
@@ -16,12 +16,14 @@ categories.workspace = true
 # out here makes an accidental `cargo publish` fail instead of claiming a name.
 publish.workspace = true
 
-# wusel-desktop is the **Linux** OS-integration backend behind `wusel_core::desktop::Desktop`:
-# freedesktop notifications (zbus) now, and the file-manager cloud-provider
-# status (libcloudproviders / zbus) as it grows. It is a swappable module — macOS
-# (File Provider) and Windows (Cloud Filter) would be their own crates. The daemon
-# injects it via `Provider::set_desktop`; on any other platform, or when D-Bus is
-# absent, nothing here is used and the engine keeps the no-op default.
+# wusel-desktop is the OS-integration backend behind `wusel_core::desktop::Desktop`.
+# Most of it is Linux-only — freedesktop notifications (zbus), the file-manager
+# cloud-provider status (libcloudproviders / zbus) — behind `cfg(target_os =
+# "linux")`, a swappable module macOS (File Provider) and Windows (Cloud Filter)
+# would each get their own equivalent of. The notify hook (an opt-in script run on
+# every notice) is the one channel that is NOT Linux-gated: it depends on nothing
+# platform-specific, so it stays available everywhere this crate builds, headless
+# boxes included. The daemon injects the whole backend via `Provider::set_desktop`.
 
 [lib]
 name = "wusel_desktop"
@@ -31,8 +33,8 @@ path = "src/lib.rs"
 wusel-core = { path = "../wusel-core" }
 tracing.workspace = true
 
-# The desktop backend is Linux-only (freedesktop D-Bus); elsewhere the crate is an
-# empty stub so `cargo build` stays clean without pulling any D-Bus deps.
+# D-Bus itself stays Linux-only; elsewhere the crate still builds (the notify
+# hook needs nothing here) without pulling in any D-Bus dependency.
 #
 # We talk D-Bus directly via `zbus` — one method call for notifications
 # (`org.freedesktop.Notifications.Notify`), and an exported object for the file

--- a/crates/wusel-desktop/src/lib.rs
+++ b/crates/wusel-desktop/src/lib.rs
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 IT Beratung Hermann GmbH
 
-//! Linux OS-integration backend behind [`wusel_core::desktop::Desktop`].
+//! OS-integration backend behind [`wusel_core::desktop::Desktop`].
 //!
-//! Two channels, both over one session D-Bus connection via `zbus` (talking the
-//! protocol directly — no higher-level crate, so no second zbus stack):
+//! Four channels. The first three are Linux/GNOME-specific and live in
+//! [`mod@linux`], the fourth is plain `std::process` and works on any platform
+//! this crate builds for:
 //!
 //! * **Notifications** — the engine's notices become freedesktop notifications
 //!   (`org.freedesktop.Notifications.Notify`), localized and severity-styled.
+//!   One session D-Bus connection via `zbus` (talking the protocol directly — no
+//!   higher-level crate, so no second zbus stack).
 //! * **File manager** — the mount registers as an `org.freedesktop.CloudProviders`
 //!   provider (the GNOME/Nautilus + GTK integration), so a file manager shows it
 //!   with a live sync status (idle / syncing / error). The daemon exports the
@@ -15,34 +18,184 @@
 //!   `.desktop` registration file it points at lives in a *system* data dir and is
 //!   installed separately ([`install_provider`]), because the collector scans only
 //!   `$XDG_DATA_DIRS`, never `~/.local/share`.
+//! * **GNOME Shell search** — [`run_search_provider`], its own D-Bus service.
+//! * **Notify hook** (opt-in, `[desktop] notify_hook` in `config.toml`) — a script
+//!   run for every notice. Deliberately **not** gated to Linux: it depends on
+//!   nothing Linux-specific (a subprocess and some environment variables), and a
+//!   headless box — the whole reason it exists — is exactly where the other three
+//!   channels have nowhere to go. See [`run_hook`].
 //!
 //! It is a swappable module: KDE Dolphin (no libcloudproviders — its own KIO /
 //! plugin mechanism), macOS (File Provider) and Windows (Cloud Filter) would each
-//! be their own backend behind the same trait. The daemon injects it with
-//! `Provider::set_desktop`.
+//! be their own backend behind the same trait for their three platform-specific
+//! channels — the notify hook needs no equivalent, it already works there. The
+//! daemon injects the whole thing once via `Provider::set_desktop`.
 //!
 //! **Fail-soft throughout.** The trait methods never block the caller (they hand
 //! work to a worker thread) and never fail: no session bus, no notification
-//! daemon, no file-manager support — the messages are dropped and logged. Desktop
+//! daemon, no file-manager support, no hook configured, a hook that cannot run —
+//! every one of those is dropped and logged, never propagated. Desktop
 //! integration can never affect whether the filesystem works.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use wusel_core::desktop::Desktop;
+use wusel_core::desktop::{Desktop, Notice};
+// `Status` is only needed by `HookOnlyDesktop`, which exists on non-Linux
+// only (see below) — importing it unconditionally would warn as unused on a
+// Linux build, where `mod linux` brings in its own copy instead.
+#[cfg(not(target_os = "linux"))]
+use wusel_core::desktop::Status;
 
 /// The OS-integration backend for this platform, for `Provider::set_desktop`. On
 /// Linux it drives notifications + the file-manager cloud-provider status for the
-/// mount at `mount_path` under `account`. On any other platform it is the engine's
-/// no-op default, so the daemon can call this unconditionally.
+/// mount at `mount_path` under `account`, plus the notify-hook script at `hook`
+/// (if configured). On any other platform, the notify hook is all there is to
+/// offer — `account`/`mount_path` go unused there, kept only so every platform
+/// takes the same signature.
 #[cfg(target_os = "linux")]
-pub fn backend(account: &str, mount_path: &Path) -> Arc<dyn Desktop> {
-    linux::backend(account, mount_path)
+pub fn backend(account: &str, mount_path: &Path, hook: Option<&Path>) -> Arc<dyn Desktop> {
+    if let Some(h) = hook {
+        check_hook(h);
+    }
+    linux::backend(account, mount_path, hook)
 }
 
 #[cfg(not(target_os = "linux"))]
-pub fn backend(_account: &str, _mount_path: &Path) -> Arc<dyn Desktop> {
-    wusel_core::desktop::null()
+pub fn backend(_account: &str, _mount_path: &Path, hook: Option<&Path>) -> Arc<dyn Desktop> {
+    match hook {
+        Some(h) => {
+            check_hook(h);
+            Arc::new(HookOnlyDesktop {
+                hook: h.to_path_buf(),
+                locale: wusel_core::desktop::ui_locale(),
+            })
+        }
+        // Nothing configured, nothing this platform can offer on its own —
+        // the true no-op, same as before this function took a `hook` argument.
+        None => wusel_core::desktop::null(),
+    }
+}
+
+/// The `Desktop` backend for a platform with no notification channel of its own
+/// (today: everything but Linux) but a configured notify hook still deserving to
+/// fire — it depends on nothing platform-specific. Status/file-changed have
+/// nowhere to go here and stay the trait's no-op defaults. Only ever
+/// constructed on a non-Linux platform (see `backend` above); cfg-gated so a
+/// Linux build, which never uses it, does not warn about dead code.
+#[cfg(not(target_os = "linux"))]
+struct HookOnlyDesktop {
+    hook: PathBuf,
+    locale: String,
+}
+
+#[cfg(not(target_os = "linux"))]
+impl Desktop for HookOnlyDesktop {
+    fn notify(&self, notice: &Notice) {
+        run_hook(Some(&self.hook), notice, &self.locale);
+    }
+    fn set_status(&self, _status: Status) {}
+}
+
+/// Log once, at start-up, whether the configured notify-hook actually looks
+/// runnable — a missing file or a missing executable bit. Advisory only: it does
+/// not stop the daemon (the file could appear later) and is not the only check —
+/// [`exec_hook`] still handles a failure at run time the same way, since the file
+/// can change between here and then.
+fn check_hook(hook: &Path) {
+    #[cfg(unix)]
+    let runnable = {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(hook).map(|m| m.permissions().mode() & 0o111 != 0)
+    };
+    #[cfg(not(unix))]
+    let runnable = std::fs::metadata(hook).map(|_| true);
+    match runnable {
+        Ok(true) => {}
+        Ok(false) => tracing::warn!(
+            hook = %hook.display(),
+            "notify_hook is not executable — notices will not reach it \
+             until `chmod +x` is run"
+        ),
+        Err(e) => tracing::warn!(
+            %e,
+            hook = %hook.display(),
+            "notify_hook does not exist yet — notices will not reach it \
+             until it does"
+        ),
+    }
+}
+
+/// Fire the notify-hook for one notice, if configured. Hands off to its own
+/// thread immediately — like every `Desktop` method, this must never make the
+/// caller wait on an external script.
+fn run_hook(hook: Option<&Path>, notice: &Notice, locale: &str) {
+    let Some(hook) = hook else { return };
+    let message = notice.localize(locale);
+    let json = notice.to_json().to_string();
+    let hook = hook.to_path_buf();
+    if let Err(e) = std::thread::Builder::new()
+        .name("wusel-notify-hook".into())
+        .spawn(move || exec_hook(&hook, &message.title, &message.body, &json))
+    {
+        tracing::debug!(%e, "could not start the notify-hook thread");
+    }
+}
+
+/// Run one notify-hook invocation to completion, on the calling (dedicated)
+/// thread. `WUSEL_NOTICE_TITLE`/`_BODY` are the localized text (what a desktop
+/// notification would also show, where one exists); `WUSEL_NOTICE_JSON` is the
+/// unlocalized structured payload from [`Notice::to_json`], for a script that
+/// wants to act on `kind` rather than parse a sentence.
+fn exec_hook(hook: &Path, title: &str, body: &str, json: &str) {
+    let mut child = match std::process::Command::new(hook)
+        .env("WUSEL_NOTICE_TITLE", title)
+        .env("WUSEL_NOTICE_BODY", body)
+        .env("WUSEL_NOTICE_JSON", json)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            // Not found, not executable, a permissions problem — all the same to
+            // the caller: the hook did not run. Warn, not debug (see
+            // `check_hook` — this is the same failure, just discovered late).
+            tracing::warn!(%e, hook = %hook.display(), "notify_hook could not start");
+            return;
+        }
+    };
+    // A broken or hanging script must not leak this thread forever: give it a
+    // generous but bounded window, then kill it. Polling rather than a blocking
+    // `wait()` is what makes the kill possible at all.
+    const HOOK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+    let start = std::time::Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                if !status.success() {
+                    tracing::debug!(
+                        hook = %hook.display(),
+                        %status,
+                        "notify_hook exited with a non-zero status"
+                    );
+                }
+                return;
+            }
+            Ok(None) if start.elapsed() > HOOK_TIMEOUT => {
+                tracing::warn!(hook = %hook.display(), "notify_hook timed out — killing it");
+                let _ = child.kill();
+                let _ = child.wait();
+                return;
+            }
+            Ok(None) => std::thread::sleep(std::time::Duration::from_millis(100)),
+            Err(e) => {
+                tracing::debug!(%e, hook = %hook.display(), "notify_hook: wait failed");
+                return;
+            }
+        }
+    }
 }
 
 /// Deliver a single notification **synchronously**, for the `wusel desktop
@@ -179,11 +332,13 @@ pub fn uninstall_provider(account: &str, dir: &Path) -> std::io::Result<bool> {
 #[cfg(target_os = "linux")]
 mod linux {
     use std::collections::HashMap;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicI32, Ordering};
     use std::sync::mpsc::{channel, Receiver, Sender};
     use std::sync::Arc;
     use std::thread::JoinHandle;
+
+    use super::run_hook;
 
     use wusel_core::desktop::{self, Desktop, Notice, Severity, Status};
     use zbus::blocking::Connection;
@@ -308,13 +463,14 @@ mod linux {
         }
     }
 
-    pub fn backend(account: &str, mount_path: &Path) -> Arc<dyn Desktop> {
+    pub fn backend(account: &str, mount_path: &Path, hook: Option<&Path>) -> Arc<dyn Desktop> {
         let (tx, rx) = channel();
         let account = account.to_string();
         let mount = mount_path.display().to_string();
+        let hook = hook.map(Path::to_path_buf);
         match std::thread::Builder::new()
             .name("wusel-desktop".into())
-            .spawn(move || worker(rx, &account, &mount))
+            .spawn(move || worker(rx, &account, &mount, hook))
         {
             Ok(worker) => Arc::new(LinuxDesktop {
                 tx,
@@ -356,7 +512,7 @@ mod linux {
         }
     }
 
-    fn worker(rx: Receiver<Msg>, account: &str, mount: &str) {
+    fn worker(rx: Receiver<Msg>, account: &str, mount: &str, hook: Option<PathBuf>) {
         let locale = desktop::ui_locale();
         // One session-bus connection for the backend's lifetime; its object server
         // dispatches incoming D-Bus calls on zbus's own task, so it keeps serving
@@ -371,8 +527,16 @@ mod linux {
                     "no session D-Bus — desktop integration disabled \
                      (notifications, file-manager status)"
                 );
-                // Drain so senders (unbounded) never wedge; do nothing with them.
-                while rx.recv().is_ok() {}
+                // The notify hook does not depend on D-Bus — a headless server is
+                // exactly where it matters most, so notices still reach it even
+                // though the desktop channel is down. `Status`/`FileChanged` stay
+                // drained: both are purely D-Bus concerns (cloud-provider status,
+                // file-manager invalidation), nothing a hook script would act on.
+                while let Ok(msg) = rx.recv() {
+                    if let Msg::Notify(notice) = msg {
+                        run_hook(hook.as_deref(), &notice, &locale);
+                    }
+                }
                 return;
             }
         };
@@ -397,10 +561,13 @@ mod linux {
 
         while let Ok(msg) = rx.recv() {
             match msg {
-                Msg::Notify(notice) => match show(&conn, &notice, &locale) {
-                    Ok(()) => tracing::debug!("desktop notification sent"),
-                    Err(e) => tracing::debug!(%e, "desktop notification not shown"),
-                },
+                Msg::Notify(notice) => {
+                    match show(&conn, &notice, &locale) {
+                        Ok(()) => tracing::debug!("desktop notification sent"),
+                        Err(e) => tracing::debug!(%e, "desktop notification not shown"),
+                    }
+                    run_hook(hook.as_deref(), &notice, &locale);
+                }
                 Msg::Status(s) => {
                     status.store(wire_status(s), Ordering::Relaxed);
                     if provider_ok {

--- a/crates/wusel-desktop/tests/notify_hook.rs
+++ b/crates/wusel-desktop/tests/notify_hook.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 IT Beratung Hermann GmbH
+
+//! The notify hook is the one channel in this crate that is *not* Linux-gated
+//! (see the crate docs) — a subprocess and some environment variables, nothing
+//! platform-specific. So unlike the D-Bus channels, it can be verified for real
+//! right here, on whatever platform `cargo test` runs on, not only inside the
+//! Linux container the FUSE/D-Bus paths need.
+//!
+//! Each test writes its own tiny shell script that records what it received,
+//! calls `wusel_desktop::backend` exactly as the daemon does, fires a real
+//! `Notice` through it, and polls for the script's output — proving the
+//! environment variables actually round-trip, not just that the code compiles.
+
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use wusel_core::desktop::Notice;
+
+const PATIENCE: Duration = Duration::from_secs(5);
+
+fn scratch_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("wusel-notify-hook-{name}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create the test scratch directory");
+    dir
+}
+
+/// Write an executable script at `path` that dumps the three `WUSEL_NOTICE_*`
+/// variables to `marker`, one per line — plain enough to assert on directly.
+fn write_hook_script(path: &Path, marker: &Path) {
+    let script = format!(
+        "#!/bin/sh\n\
+         {{\n\
+         echo \"TITLE=$WUSEL_NOTICE_TITLE\"\n\
+         echo \"BODY=$WUSEL_NOTICE_BODY\"\n\
+         echo \"JSON=$WUSEL_NOTICE_JSON\"\n\
+         }} > {marker:?}\n"
+    );
+    let mut f = std::fs::File::create(path).expect("create the hook script");
+    f.write_all(script.as_bytes())
+        .expect("write the hook script");
+    drop(f);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+            .expect("make the hook script executable");
+    }
+}
+
+/// Poll for the marker file `run_hook`'s background thread writes, rather than
+/// sleeping a fixed amount — the hook runs asynchronously by design (see
+/// `run_hook`'s doc comment), so the test has to wait for it the same way a real
+/// admin's monitoring would.
+fn wait_for_marker(marker: &Path) -> String {
+    let start = Instant::now();
+    loop {
+        if let Ok(contents) = std::fs::read_to_string(marker) {
+            return contents;
+        }
+        if start.elapsed() > PATIENCE {
+            panic!("the notify hook never wrote {}", marker.display());
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+#[test]
+fn a_notice_reaches_the_hook_with_localized_text_and_raw_json() {
+    let dir = scratch_dir("basic");
+    let marker = dir.join("marker.txt");
+    let hook = dir.join("hook.sh");
+    write_hook_script(&hook, &marker);
+
+    let desktop = wusel_desktop::backend("test-account", Path::new("/nonexistent"), Some(&hook));
+    desktop.notify(&Notice::UploadFailed {
+        path: "big.iso".into(),
+        reason: "quota exceeded".into(),
+    });
+
+    let contents = wait_for_marker(&marker);
+    assert!(contents.contains("TITLE=Upload failed"), "{contents}");
+    assert!(contents.contains("big.iso"), "{contents}");
+    assert!(contents.contains("quota exceeded"), "{contents}");
+    // The JSON line carries the stable, unlocalized `kind` — what a script
+    // matches on instead of parsing the English/German sentence.
+    assert!(
+        contents.contains("JSON={\"kind\":\"upload-failed\""),
+        "{contents}"
+    );
+}
+
+#[test]
+fn no_hook_configured_is_a_silent_no_op() {
+    // `backend(..., None)` must not panic, spawn anything, or otherwise behave
+    // differently from before this feature existed.
+    let desktop = wusel_desktop::backend("test-account", Path::new("/nonexistent"), None);
+    desktop.notify(&Notice::ConnectionRestored {
+        server: "https://cloud.example.org".into(),
+    });
+    // Nothing to assert beyond "this returned" — there is no channel left for
+    // it to have reached.
+}
+
+#[test]
+fn a_missing_hook_is_logged_and_skipped_not_fatal() {
+    let dir = scratch_dir("missing");
+    let hook = dir.join("does-not-exist.sh");
+
+    // Must not panic — `check_hook`'s start-up warning and `exec_hook`'s
+    // spawn-error handling are both supposed to swallow this.
+    let desktop = wusel_desktop::backend("test-account", Path::new("/nonexistent"), Some(&hook));
+    desktop.notify(&Notice::ConnectionLost {
+        server: "https://cloud.example.org".into(),
+    });
+    // Give the background thread a moment to run (and not panic) before the
+    // process exits; there is nothing further to observe.
+    std::thread::sleep(Duration::from_millis(100));
+}
+
+#[test]
+fn a_non_executable_hook_is_logged_and_skipped_not_fatal() {
+    let dir = scratch_dir("not-executable");
+    let hook = dir.join("hook.sh");
+    std::fs::write(&hook, "#!/bin/sh\necho should-not-run\n").expect("write the hook script");
+    // Deliberately no chmod +x.
+
+    let desktop = wusel_desktop::backend("test-account", Path::new("/nonexistent"), Some(&hook));
+    desktop.notify(&Notice::ConnectionLost {
+        server: "https://cloud.example.org".into(),
+    });
+    std::thread::sleep(Duration::from_millis(100));
+}

--- a/crates/wusel-fuse/src/fs.rs
+++ b/crates/wusel-fuse/src/fs.rs
@@ -426,17 +426,47 @@ impl Filesystem for NcFs {
         }
     }
 
-    /// Filesystem statistics. We are a virtual, server-backed filesystem, so we
-    /// advertise a large capacity with plenty free — otherwise applications that
-    /// check available space before saving would see zero and refuse.
+    /// Filesystem statistics, from the account's real Nextcloud quota where the
+    /// substrate has one cached (see `Substrate::quota`).
+    ///
+    /// Where it does not — nothing fetched yet, or the server answered with no
+    /// usable free-space figure (an account with no quota answers `-3`,
+    /// "unlimited"; there are sentinels for "unknown" and "not yet computed"
+    /// too) — free space is *unknown*, and `statfs` has no way to say so:
+    /// POSIX only says undefined fields are zero, and zero free is exactly what
+    /// makes applications refuse to save. So we advertise a large fixed amount
+    /// free, as every filesystem in this position does (rclone's VFS uses this
+    /// same 1 PiB; davfs2 picks a similar invented figure).
+    ///
+    /// `used` is still reported truthfully there, because Nextcloud answers
+    /// `quota-used-bytes` with a real byte count even when it will not name a
+    /// limit — so `df` shows what is actually stored, with the invented free
+    /// space added on top rather than replacing it. Reporting zero used (which
+    /// is what "1 PiB, all free" amounted to) threw away a number we had.
     fn statfs(&self, _req: &Request_, _ino: INodeNo, reply: ReplyStatfs) {
         const BSIZE: u32 = 512;
-        const TOTAL_BLOCKS: u64 = 1 << 41; // ~1 PiB at 512-byte blocks
+        /// Stands in for "free space unknown" — never a claim about the server.
+        const PLACEHOLDER_FREE_BLOCKS: u64 = 1 << 41; // 1 PiB at 512-byte blocks
         const TOTAL_INODES: u64 = 1 << 32;
+
+        let quota = self.substrate.quota();
+        let (blocks, free) = match quota.and_then(|q| q.available.map(|a| (q.used, a))) {
+            Some((used, available)) => (
+                used.saturating_add(available).div_ceil(u64::from(BSIZE)),
+                available.div_ceil(u64::from(BSIZE)),
+            ),
+            None => {
+                let used_blocks = quota.map_or(0, |q| q.used).div_ceil(u64::from(BSIZE));
+                (
+                    PLACEHOLDER_FREE_BLOCKS.saturating_add(used_blocks),
+                    PLACEHOLDER_FREE_BLOCKS,
+                )
+            }
+        };
         reply.statfs(
-            TOTAL_BLOCKS,
-            TOTAL_BLOCKS,
-            TOTAL_BLOCKS,
+            blocks,
+            free,
+            free,
             TOTAL_INODES,
             TOTAL_INODES,
             BSIZE,
@@ -831,6 +861,12 @@ pub fn mount(mountpoint: &std::path::Path, mut provider: Provider) -> anyhow::Re
     // the network and file pools. The Provider hands over its own parts rather
     // than having us assemble them from pieces we would have to be told about.
     let ctx = provider.substrate_context();
+    // Ask for the storage quota now rather than letting the first `statfs` call
+    // trigger it: that call must not wait for the network (see `QuotaCache`), so
+    // without this the first `df` after every mount reports the placeholder.
+    if let Some(quota) = &ctx.quota {
+        quota.prime();
+    }
     let pools = Pools {
         db_readers: dispatch_threads.max(2),
         net: dispatch_threads.max(4),

--- a/crates/wusel-fuse/tests/statfs_quota_e2e.rs
+++ b/crates/wusel-fuse/tests/statfs_quota_e2e.rs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 IT Beratung Hermann GmbH
+
+//! Real FUSE mount end-to-end: `statfs` on the mount must eventually report the
+//! server's *real* storage quota, not the fallback placeholder — the frontend
+//! (`fs.rs`), the substrate (`Substrate::quota`) and the cache
+//! (`QuotaCache`/`WebDavClient::quota`) all have their own unit/HTTP-level
+//! coverage, but only a real kernel mount proves the whole chain is actually
+//! wired together. Needs `/dev/fuse`, so it runs only on Linux (the podman
+//! container); it is a no-op elsewhere.
+#![cfg(target_os = "linux")]
+
+mod common;
+
+use std::ffi::CString;
+
+/// The fixture `MountFixture::start` seeds: `Notes.txt` ("hello"),
+/// `Sub Folder/deep.txt` ("nested") and the hidden `.Trash-1000/files/old.txt`
+/// ("gone") — wusel-mock's `quota-used-bytes` mirrors the served tree's real
+/// size, trash included, so this is *all* of it, not just what the mount shows.
+const USED: u64 = 5 + 6 + 4;
+/// wusel-mock's fixed `quota-available-bytes` (see `entry_xml` in wusel-mock).
+const AVAILABLE: u64 = 1_000_000_000;
+/// Matches `fs.rs`'s `statfs` block size.
+const BSIZE: u64 = 512;
+
+#[test]
+fn statfs_reflects_the_servers_real_quota() {
+    let m = common::MountFixture::start("statfs-quota");
+    let cpath = CString::new(m.mnt.to_str().unwrap()).unwrap();
+
+    let stat = || -> libc::statvfs {
+        let mut st: libc::statvfs = unsafe { std::mem::zeroed() };
+        let rc = unsafe { libc::statvfs(cpath.as_ptr(), &mut st) };
+        assert_eq!(rc, 0, "statvfs syscall failed");
+        st
+    };
+
+    let expected_blocks = (USED + AVAILABLE).div_ceil(BSIZE);
+    let expected_free = AVAILABLE.div_ceil(BSIZE);
+
+    // The very first `statfs` after mount can still see the placeholder: the
+    // real quota is fetched in the background (see `QuotaCache`) so it never
+    // blocks the call that triggers it. Poll rather than assert on the first
+    // reading.
+    common::eventually("statfs settles on the server's real quota", || {
+        stat().f_blocks == expected_blocks
+    });
+
+    let st = stat();
+    assert_eq!(st.f_blocks, expected_blocks, "total = used + available");
+    assert_eq!(st.f_bfree, expected_free);
+    assert_eq!(st.f_bavail, expected_free);
+    assert_eq!(st.f_bsize, BSIZE);
+
+    // `m` drops here: unmount + cleanup.
+}

--- a/crates/wusel-mock/src/lib.rs
+++ b/crates/wusel-mock/src/lib.rs
@@ -866,6 +866,21 @@ fn entry_xml(cfg: &Config, rel: &str, meta: &Metadata) -> String {
         )
     };
 
+    // Real Nextcloud only reports quota on the account root, and the client
+    // only ever asks there (a Depth-0 PROPFIND of it) — so that is the only
+    // place the mock renders it. `used` mirrors the served tree's real size,
+    // so a test can assert against a number it did not have to hardcode
+    // separately; `available` is a fixed, arbitrary "still room" figure.
+    let quota = if is_dir && rel.is_empty() {
+        format!(
+            "\x20     <d:quota-used-bytes>{}</d:quota-used-bytes>\n\
+             \x20     <d:quota-available-bytes>1000000000</d:quota-available-bytes>\n",
+            dir_size(&cfg.root)
+        )
+    } else {
+        String::new()
+    };
+
     format!(
         "  <d:response>\n\
          \x20   <d:href>{href}</d:href>\n\
@@ -874,9 +889,25 @@ fn entry_xml(cfg: &Config, rel: &str, meta: &Metadata) -> String {
          \x20     <d:getlastmodified>{last_modified}</d:getlastmodified>\n\
          \x20     <d:getetag>\"{etag}\"</d:getetag>\n\
          \x20     <oc:fileid>{file_id}</oc:fileid>\n\
+         {quota}\
          \x20   </d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>\n\
          \x20 </d:response>\n"
     )
+}
+
+/// Recursive total size of every regular file under `path` — the mock's stand-in
+/// for a real storage quota's "used" figure.
+fn dir_size(path: &Path) -> u64 {
+    let Ok(rd) = std::fs::read_dir(path) else {
+        return 0;
+    };
+    rd.flatten()
+        .map(|e| match e.metadata() {
+            Ok(m) if m.is_dir() => dir_size(&e.path()),
+            Ok(m) => m.len(),
+            Err(_) => 0,
+        })
+        .sum()
 }
 
 /// Absolute href under the user root, each path segment percent-encoded; a

--- a/crates/wusel-mock/tests/quota_cache.rs
+++ b/crates/wusel-mock/tests/quota_cache.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 IT Beratung Hermann GmbH
+
+//! Behavioural test of [`QuotaCache`] against a real `wusel-mock` server — the
+//! caching/refresh logic on top of the wire-level `WebDavClient::quota` test in
+//! `webdav_client.rs`.
+
+mod common;
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use wusel_core::model::Quota;
+use wusel_core::runtime::QuotaCache;
+use wusel_core::webdav::WebDavClient;
+
+fn client_for(addr: &str) -> WebDavClient {
+    WebDavClient::new(
+        reqwest::Client::new(),
+        &format!("http://{addr}"),
+        "alice",
+        "pw",
+    )
+}
+
+#[test]
+fn a_stale_cache_answers_at_once_and_refreshes_in_the_background() {
+    let base = std::env::temp_dir().join(format!("wusel-mock-quota-cache-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&base);
+    let fixture = base.join("fixture");
+    std::fs::create_dir_all(&fixture).unwrap();
+    std::fs::write(fixture.join("Notes.txt"), vec![b'x'; 4096]).unwrap();
+
+    let mock = common::Mock::serve(&fixture);
+    let dav = client_for(&mock.addr);
+    let rt = Arc::new(
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("build a runtime"),
+    );
+    let cache = Arc::new(QuotaCache::new(
+        dav,
+        Arc::clone(&rt),
+        Duration::from_millis(20),
+    ));
+
+    // Nothing has landed yet: the very first call must answer immediately with
+    // the zero default, not block on the network — it only kicks a fetch off
+    // in the background for next time.
+    let before_any_fetch = Instant::now();
+    let first = cache.snapshot();
+    assert!(
+        before_any_fetch.elapsed() < Duration::from_millis(200),
+        "snapshot must never block on the network"
+    );
+    assert_eq!(first, Quota::default());
+
+    // Poll until the background fetch has landed (bounded, so a real failure
+    // fails the test instead of hanging it).
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut seen = cache.snapshot();
+    while seen.available.is_none() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(20));
+        seen = cache.snapshot();
+    }
+    assert_eq!(seen.used, 4096, "the mock reports the fixture's real size");
+    assert_eq!(seen.available, Some(1_000_000_000));
+
+    std::fs::remove_dir_all(&base).ok();
+}
+
+#[test]
+fn priming_fetches_without_anyone_asking_for_a_value() {
+    // What the mount does at start-up: without it, the *first* `df` after a
+    // mount is the call that triggers the fetch — and it cannot wait for it, so
+    // it always reports the placeholder.
+    let base = std::env::temp_dir().join(format!("wusel-mock-quota-prime-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&base);
+    let fixture = base.join("fixture");
+    std::fs::create_dir_all(&fixture).unwrap();
+    std::fs::write(fixture.join("Notes.txt"), vec![b'x'; 4096]).unwrap();
+
+    let mock = common::Mock::serve(&fixture);
+    let rt = Arc::new(
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("build a runtime"),
+    );
+    let cache = Arc::new(QuotaCache::new(
+        client_for(&mock.addr),
+        Arc::clone(&rt),
+        Duration::from_secs(60),
+    ));
+
+    cache.prime();
+
+    // The value has to arrive without a single `snapshot()` having asked for it
+    // first — polling here reads the cache, but priming is what filled it.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut seen = cache.snapshot();
+    while seen.available.is_none() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(20));
+        seen = cache.snapshot();
+    }
+    assert_eq!(
+        seen.available,
+        Some(1_000_000_000),
+        "priming must have fetched the quota on its own"
+    );
+
+    std::fs::remove_dir_all(&base).ok();
+}

--- a/crates/wusel-mock/tests/webdav_client.rs
+++ b/crates/wusel-mock/tests/webdav_client.rs
@@ -60,6 +60,25 @@ async fn propfind_dir_lists_children_over_http() {
 }
 
 #[tokio::test]
+async fn quota_reaches_the_server_over_http() {
+    let base = std::env::temp_dir().join(format!("wusel-mock-dav-quota-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&base);
+    let fixture = base.join("fixture");
+    std::fs::create_dir_all(&fixture).unwrap();
+    std::fs::write(fixture.join("Notes.txt"), vec![b'x'; 4096]).unwrap();
+
+    let mock = common::Mock::serve(&fixture);
+    let dav = client_for(&mock.addr);
+
+    let quota = dav.quota().await.expect("quota should succeed");
+
+    assert_eq!(quota.used, 4096, "the mock reports the fixture's real size");
+    assert_eq!(quota.available, Some(1_000_000_000));
+
+    std::fs::remove_dir_all(&base).ok();
+}
+
+#[tokio::test]
 async fn write_verbs_reach_the_server() {
     let base = std::env::temp_dir().join(format!("wusel-mock-dav-write-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&base);

--- a/crates/wusel/src/main.rs
+++ b/crates/wusel/src/main.rs
@@ -475,12 +475,13 @@ fn cmd_mount(account: &Account, mountpoint: Option<&str>) -> anyhow::Result<()> 
         .unwrap_or_else(|_| mountpoint.to_path_buf());
 
     // The platform OS-integration backend (Linux notifications + the file-manager
-    // cloud-provider status for this account's mountpoint; a no-op elsewhere or
-    // when D-Bus is absent — fail-soft). Built *before* the first network call,
-    // not after the provider: the very first thing that can go wrong is that the
-    // server cannot be reached, and a start-up that says nothing is exactly the
-    // silence this exists to break.
-    let desktop = wusel_desktop::backend(account.name(), &target);
+    // cloud-provider status for this account's mountpoint, plus the notify-hook
+    // script if configured; a no-op elsewhere or when D-Bus is absent —
+    // fail-soft). Built *before* the first network call, not after the provider:
+    // the very first thing that can go wrong is that the server cannot be
+    // reached, and a start-up that says nothing is exactly the silence this
+    // exists to break.
+    let desktop = wusel_desktop::backend(account.name(), &target, settings.notify_hook.as_deref());
     // One shared answer to "can we reach the server?", fed by every request the
     // engine makes, and the only thing allowed to notify about it.
     let health = std::sync::Arc::new(wusel_core::health::Reachability::new(
@@ -1331,11 +1332,12 @@ fn cmd_unpin(account: &Account, path: &str) -> anyhow::Result<()> {
 /// fail. The state is already correct either way; this is only how quickly it
 /// is *shown*.
 fn announce_emblem(account: &Account, remote: &str) {
-    let mount = account
-        .settings()
+    let settings = account.settings();
+    let mount = settings
         .mount_point
+        .clone()
         .unwrap_or_else(|| account.default_mountpoint());
-    let desktop = wusel_desktop::backend(account.name(), &mount);
+    let desktop = wusel_desktop::backend(account.name(), &mount, settings.notify_hook.as_deref());
     desktop.file_changed(&mount.join(remote).to_string_lossy());
 }
 

--- a/documentation/antora-playbook-site.yml
+++ b/documentation/antora-playbook-site.yml
@@ -34,6 +34,15 @@ content:
         'v(?<version>+({0..9}).+({0..9}).+({0..9}))': $<version>
         main: latest
 
+antora:
+  extensions:
+    # Full-text search; see antora-playbook.yml for what the extension adds.
+    - require: '@antora/lunr-extension'
+      # This site carries every release as its own version. Indexing them all
+      # would answer a query with a hit from an old release as readily as from
+      # the current one, so only "latest" goes into the index.
+      index_latest_only: true
+
 runtime:
   log:
     format: json

--- a/documentation/antora-playbook.yml
+++ b/documentation/antora-playbook.yml
@@ -23,6 +23,14 @@ content:
       start_path: documentation
       version: latest
 
+antora:
+  extensions:
+    # Full-text search. The extension indexes the generated pages and writes the
+    # index beside the site (search-index.js); the search box in the header, the
+    # client-side UI and its stylesheet come from the UI bundle. Everything runs
+    # in the reader's browser — no search server, no external service.
+    - require: '@antora/lunr-extension'
+
 runtime:
   log:
     format: json

--- a/documentation/build.sh
+++ b/documentation/build.sh
@@ -12,6 +12,29 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
+# The lunr search extension is a library, not a command: antora `require`s it
+# while building. mise gives every npm package its own prefix, so it is not a
+# sibling of antora's own node_modules and plain module resolution misses it —
+# NODE_PATH is what makes `require: '@antora/lunr-extension'` in the playbooks
+# resolve. mise gives every npm package its own prefix; the module lives *some*
+# levels below it, but not always at the same subpath — mise 2027.x changed the
+# npm layout, and a hardcoded `$prefix/lib/node_modules` (correct on 2026.x)
+# then pointed at nothing, so antora failed with "Cannot find module". Find the
+# module wherever mise actually put it and set NODE_PATH to the directory that
+# holds its `@antora/` scope, so this survives the next layout change too.
+if ! lunr_prefix="$(mise where "npm:@antora/lunr-extension" 2>/dev/null)" || [ -z "$lunr_prefix" ]; then
+  echo "build.sh: @antora/lunr-extension is missing — run: mise install 'npm:@antora/lunr-extension'" >&2
+  exit 1
+fi
+lunr_module="$(find "$lunr_prefix" -type d -path '*/@antora/lunr-extension' -print 2>/dev/null | head -1)"
+if [ -z "$lunr_module" ]; then
+  echo "build.sh: @antora/lunr-extension installed at $lunr_prefix but its module dir was not found" >&2
+  exit 1
+fi
+# NODE_PATH must hold the dir *containing* the @antora scope, i.e. two up.
+NODE_PATH="$(cd "$lunr_module/../.." && pwd)"
+export NODE_PATH
+
 # Diagrams are pre-rendered committed SVGs (see diagrams/ and `mise run
 # docs-diagrams`), so this build needs nothing beyond antora — no server.
 #

--- a/documentation/modules/ROOT/nav.adoc
+++ b/documentation/modules/ROOT/nav.adoc
@@ -18,6 +18,7 @@
 * xref:how-to/add-another-account.adoc[Add another account]
 * xref:how-to/keep-files-offline.adoc[Keep files offline]
 * xref:how-to/connect-to-a-self-signed-server.adoc[Connect to a server with a private certificate]
+* xref:how-to/set-up-a-notify-hook.adoc[Set up a notify hook]
 * xref:how-to/diagnose-a-problem.adoc[Diagnose a problem]
 * xref:how-to/uninstall.adoc[Uninstall]
 

--- a/documentation/modules/ROOT/pages/explanation/desktop-integration.adoc
+++ b/documentation/modules/ROOT/pages/explanation/desktop-integration.adoc
@@ -125,6 +125,32 @@ many of whom do not read English. Everything else — logs, CLI output, terminal
 errors — stays English. Adding a language is one match arm; a background systemd
 service that does not inherit `LANG` just falls back to English (safe).
 
+[#notify-hook]
+=== Notify hook: reaching a headless box
+
+Every channel above assumes a session bus. A server or a container has none —
+notices there have nowhere to go, `NullDesktop` swallows them, and the first
+sign of trouble is the one thing on this page nobody reads: the journal.
+
+`[desktop] notify_hook` (optional, off by default) closes that gap: a script
+run for every notice, independent of whether a session bus exists at all — it
+still fires from inside the Linux backend's "no session bus" branch, not only
+alongside a working D-Bus connection. It is additive, not a replacement: the
+engine logs every notice at `warn` regardless of whether a hook is configured,
+so there is always a trail in the journal either way. The hook is for an admin
+who wants to *act* on a notice — forward it to mail, a webhook, an alerting
+system — rather than wait for someone to read a log.
+
+The script receives the same localized text a D-Bus toast would show
+(`WUSEL_NOTICE_TITLE`/`_BODY`), plus the raw, unlocalized payload as JSON
+(`WUSEL_NOTICE_JSON` — `kind`, `severity`, and the notice's own fields, from
+`Notice::to_json`) for a script that wants to act on `kind` rather than parse a
+sentence that changes with the user's language. Fire-and-forget with a bounded
+timeout: a missing, non-executable, or hanging script is logged and skipped,
+never allowed to block a notice or the daemon. See
+xref:how-to/set-up-a-notify-hook.adoc[Set up a notify hook] for the concrete
+recipe.
+
 === "Can we reach the server?" — one shared answer (`health::Reachability`)
 
 Of those cases, *the connection is gone* is the one the user cannot diagnose at

--- a/documentation/modules/ROOT/pages/how-to/diagnose-a-problem.adoc
+++ b/documentation/modules/ROOT/pages/how-to/diagnose-a-problem.adoc
@@ -233,6 +233,24 @@ xref:reference/limitations.adoc#cache-clear-needs-unmount[known limitation] rath
 than a technical necessity. If a problem survives `cache clear`, it is not a
 caching problem.
 
+== `df` shows a petabyte
+
+Check which case the mount is in:
+
+[source,sh]
+----
+journalctl --user -u wusel@default | grep quota
+----
+
+`storage quota updated …` means the numbers are the server's. `… no usable
+free-space figure …` means the account has no quota configured, and the size is
+a stand-in — assign the account a quota in Nextcloud (*Administration settings →
+Users*) if you want real numbers. Neither is a fault: see
+xref:reference/limitations.adoc#df-without-a-quota[Known limitations].
+
+No `quota` line at all means the fetch has not finished yet — it runs at mount
+and is retried on access; give it a moment and look again.
+
 == What a conflict should look like
 
 An upload that loses against a newer server version keeps both files: the

--- a/documentation/modules/ROOT/pages/how-to/set-up-a-notify-hook.adoc
+++ b/documentation/modules/ROOT/pages/how-to/set-up-a-notify-hook.adoc
@@ -1,0 +1,126 @@
+////
+  // SPDX-License-Identifier: Apache-2.0
+  // Copyright 2026 IT Beratung Hermann GmbH
+////
+
+= Set up a notify hook
+:description: Run a script on every user notice — the escape hatch for a headless server, where the desktop notification channel has nowhere to go.
+
+On a desktop, a conflicted copy or a failed upload shows up as a notification.
+On a headless server there is no session bus for that notification to reach —
+it is logged and otherwise silently dropped. A *notify hook* is a script Wusel
+runs for every notice, so something still happens: mail an admin, post to a
+webhook, page whoever is on call.
+
+This is additive, not a replacement for watching the journal
+(`journalctl --user -u wusel@default`) — logging happens either way. Set this
+up if nobody actively watches the journal, or as a second, faster path on top
+of it. See xref:explanation/desktop-integration.adoc#notify-hook[why this
+exists] for the reasoning.
+
+== Write the script
+
+The script is invoked with no arguments; everything about the notice arrives
+as environment variables:
+
+[cols="1,3"]
+|===
+| Variable | Contents
+
+| `WUSEL_NOTICE_TITLE`
+| The localized title — the same text a desktop toast would show.
+
+| `WUSEL_NOTICE_BODY`
+| The localized body text.
+
+| `WUSEL_NOTICE_JSON`
+| The unlocalized, structured payload: `kind`, `severity`, and the notice's own
+  fields (e.g. `path`, `copy` for a conflict). Use this, not `_TITLE`/`_BODY`,
+  to act on a specific *kind* of notice — it does not change with the server's
+  or user's language.
+|===
+
+A minimal example that mails an admin address, e.g. `/etc/wusel/on-notice`:
+
+[source,sh]
+----
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+set -eu
+
+to="admin@example.org"
+echo "$WUSEL_NOTICE_BODY" | mail -s "wusel: $WUSEL_NOTICE_TITLE" "$to"
+----
+
+An example that only escalates the notices that actually need action, using
+`WUSEL_NOTICE_JSON`'s `kind` field (this needs `jq`):
+
+[source,sh]
+----
+#!/bin/sh
+set -eu
+
+kind=$(printf '%s' "$WUSEL_NOTICE_JSON" | jq -r .kind)
+case "$kind" in
+  upload-failed|connection-lost)
+    curl -fsS -d "$WUSEL_NOTICE_BODY" "https://ntfy.example.org/wusel-alerts"
+    ;;
+  *)
+    ;; # conflict copies, stale-copy notes etc. — journal already has them
+esac
+----
+
+Make it executable:
+
+[source,sh]
+----
+chmod +x /etc/wusel/on-notice
+----
+
+A missing executable bit is the most common way this silently does nothing —
+Wusel checks for it at start-up and logs a warning
+(`journalctl --user -u wusel@default`), but the check cannot run before the
+file exists, so a typo in the path only ever shows up there too.
+
+== Configure it
+
+[source,toml]
+----
+[desktop]
+notify_hook = "/etc/wusel/on-notice"
+----
+
+Restart the mount (or start it, if it was not running) for the setting to take
+effect — see xref:how-to/mount-at-login.adoc[Mount at login] for the
+`systemctl`/`wusel service` commands.
+
+== Test it
+
+There is no dedicated diagnostic command for the hook (unlike
+`wusel desktop notify` for D-Bus) — a notice is, deliberately, a rare event.
+Two ways to check it works:
+
+* *Standalone*, without waiting for a real incident — run the script by hand
+  with the same environment variables it would receive:
++
+[source,sh]
+----
+WUSEL_NOTICE_TITLE="Test" \
+WUSEL_NOTICE_BODY="This is a test." \
+WUSEL_NOTICE_JSON='{"kind":"upload-failed","severity":"error","path":"x","reason":"test"}' \
+  /etc/wusel/on-notice
+----
+* *End to end* — provoke a real notice, e.g. edit a file both locally and on
+  the Nextcloud web UI before the mount re-lists it, which produces a
+  `conflict-copy` notice.
+
+== Keep in mind
+
+* The hook runs with a bounded timeout (currently 10 seconds); a script that
+  hangs longer is killed, logged, and skipped for that notice — it never blocks
+  a notice or the mount.
+* A missing script, a non-executable one, or a non-zero exit is logged and
+  otherwise has no effect — never a reason the mount stops working.
+* The hook fires for every notice, with no built-in rate limiting beyond what
+  already applies to notices themselves (e.g. one notice per hundreds of
+  pinned files going stale together, not hundreds of hook invocations).

--- a/documentation/modules/ROOT/pages/project/contributing.adoc
+++ b/documentation/modules/ROOT/pages/project/contributing.adoc
@@ -116,7 +116,7 @@ environment].
 
 The diagrams under `documentation/diagrams/*.d2` are rendered to **committed**
 SVGs, and the docs build embeds those — it never runs `d2`, which is why the
-Pages workflow installs nothing but antora. The workflow after editing one:
+Pages workflow installs no more than antora and the search extension. The workflow after editing one:
 
 [source,bash]
 ----

--- a/documentation/modules/ROOT/pages/project/roadmap.adoc
+++ b/documentation/modules/ROOT/pages/project/roadmap.adoc
@@ -78,6 +78,13 @@ fresh app password is in place.
   shipped docs) and `v0.2.0` → `0.2.0` join the menu, and each `vX.Y.Z` from then
   on appears automatically. Local editing is unaffected — `antora-playbook.yml`
   still previews the working tree via `build.sh` / `build.sh watch`.
+* ✅ **Full-text search over the documentation.** `@antora/lunr-extension` builds
+  a lunr index while the site is generated and ships the browser-side UI, so the
+  search box in the header works with no search server and no external service.
+  The published site indexes `latest` only — a hit never comes from a superseded
+  release. The dropdown wears the site's own palette because the UI bundle
+  carries `css/search.css`, which is what makes the extension leave its default
+  stylesheet out.
 * ⬜ Re-crawl a pinned directory to pick up files added after the pin; prefetch
   policy and exclusion patterns.
 * ✅ **Serve a stale pinned file when the server is unreachable.** It was a

--- a/documentation/modules/ROOT/pages/reference/configuration.adoc
+++ b/documentation/modules/ROOT/pages/reference/configuration.adoc
@@ -68,6 +68,16 @@ applies.
   re-listed on next access only if its last listing is older than this, so a
   burst of events collapses into at most one PROPFIND per window.
 
+| `quota_revalidate_secs`
+| integer (seconds)
+| `60`
+| How long a fetched storage quota — what `df` on the mount reports — is
+  trusted before it is refreshed. Coarser than `revalidate_secs` on purpose:
+  a quota changes far less often than a directory's contents, and some
+  applications ask for it before every save. See
+  xref:reference/limitations.adoc#df-without-a-quota[Known limitations] for what
+  `df` shows when the account has no quota at all.
+
 | `text_merge`
 | boolean
 | `false`
@@ -212,6 +222,15 @@ path.
   opening a file caches it, so an indexer walking the mount would hydrate
   everything it touches. KDE Baloo ignores such markers and needs its own
   exclude.
+
+| `notify_hook`
+| path
+| unset
+| Run this script on every user notice, in addition to the desktop
+  notification. Off by default. See
+  xref:how-to/set-up-a-notify-hook.adoc[Set up a notify hook] — it is the
+  escape hatch for a headless box with no D-Bus session, where a notice
+  otherwise reaches nobody.
 |===
 
 == `[state]`
@@ -242,6 +261,7 @@ max_age  = "30d"          # default: age alone never evicts
 [sync]
 revalidate_secs = 60      # default 30
 push_floor_secs = 10      # default 5
+quota_revalidate_secs = 300  # default 60
 text_merge      = true    # default false
 refresh_pinned  = "auto"  # default "ask"
 open_pinned     = "offline"  # default "newest"
@@ -258,7 +278,8 @@ ca_cert = "/etc/pki/tls/certs/my-ca.pem"   # default: OS trust store only
 keyring = false           # default true
 
 [desktop]
-exclude_from_indexers = false   # default true
+exclude_from_indexers = false            # default true
+notify_hook = "/etc/wusel/on-notice"     # default unset
 
 [state]
 db_path = "/var/tmp/wusel/state.sqlite"

--- a/documentation/modules/ROOT/pages/reference/limitations.adoc
+++ b/documentation/modules/ROOT/pages/reference/limitations.adoc
@@ -152,3 +152,50 @@ manage and simply fail. Leftovers can be found and removed by hand:
 getfattr -R -n user.wusel.state ~ 2>/dev/null   # find copies carrying it
 setfattr -x user.wusel.state <file>             # drop it from one file
 ----
+
+[#df-without-a-quota]
+== `df` reports a stand-in size when the account has no quota
+
+[source,console]
+----
+$ df -h ~/Wusel
+Filesystem      Size  Used Avail Use% Mounted on
+wusel           1.0P  586M  1.0P   1% /home/you/Wusel
+----
+
+The *used* figure is real. The 1 PiB is not: it stands for "free space
+unknown", and it appears whenever the server names no limit for the account.
+
+*Why it happens.* Wusel asks the server for the account's quota (the WebDAV
+properties `quota-used-bytes` and `quota-available-bytes`). An account with no
+quota configured gets a truthful used figure and `-3` for the available one —
+Nextcloud's sentinel for "unlimited". There are two more, `-1` for "not yet
+computed" and `-2` for "unknown". None of them is a number of free bytes, so
+there is nothing to report.
+
+*Why not report zero.* `statfs(2)` says undefined fields are zero, and zero
+free is precisely the answer that makes applications refuse to save before they
+have tried. So the mount advertises a large fixed amount instead — the same
+1 PiB rclone's VFS uses in the same position. The real used figure is added on
+top of it rather than replacing it, so `df` still shows what is actually
+stored.
+
+*What to do about it.* Assign the account a quota in Nextcloud (*Administration
+settings → Users*). `df` then reports the server's real numbers, within
+`quota_revalidate_secs` (xref:reference/configuration.adoc[Configuration]) at
+the latest. Nothing else changes: the placeholder never limited what could be
+stored, it only meant the limit was unknown.
+
+The mount says which case it is in, at `info`, once per fetch:
+
+[source,console]
+----
+$ journalctl --user -u wusel@default | grep quota
+... storage quota updated used=534696340 available=10202721900
+... the server reported no usable free-space figure (unlimited, or not yet
+    computed) — statfs keeps its placeholder used=614388147
+----
+
+The official Nextcloud desktop client hits the same wall and sidesteps it: for
+an unlimited account it shows "X in use" with no total and no bar. A filesystem
+has no such option — `df` has fields that must be filled.

--- a/documentation/modules/ROOT/pages/reference/platform-support.adoc
+++ b/documentation/modules/ROOT/pages/reference/platform-support.adoc
@@ -76,8 +76,11 @@ none of the rest.
 
 | No desktop (server, SSH)
 | supported
-| The mount and the CLI. The integration disables itself silently. Note that a
-  headless machine usually has no unlocked keyring either — see
+| The mount and the CLI. The D-Bus channels disable themselves silently — but
+  notices still have a way out here: a
+  xref:how-to/set-up-a-notify-hook.adoc[notify hook] runs a script for each one
+  and needs no session bus. Note that a headless machine usually has no
+  unlocked keyring either — see
   xref:explanation/credentials-and-trust.adoc[Credentials and trust].
 |===
 

--- a/documentation/modules/ROOT/pages/tutorials/on-a-server.adoc
+++ b/documentation/modules/ROOT/pages/tutorials/on-a-server.adoc
@@ -238,7 +238,10 @@ it touches.
   filesystem never depends on it.
 * *The journal is your feedback channel.* `journalctl --user -u wusel@default -f`.
   What would have been a desktop notification — a failed upload, a lost
-  connection — is a `WARN` line there.
+  connection — is a `WARN` line there. Where nobody watches the journal, a
+  xref:how-to/set-up-a-notify-hook.adoc[notify hook] pushes those same few
+  messages somewhere that is watched — mail, a webhook, your alerting. It
+  needs no session bus, which is the point of it.
 * *Watch for parked uploads.* `wusel status` marks an upload `PARKED` when it
   failed permanently, for instance on a full quota. Nothing retries a parked
   upload on its own, and on an unattended machine nobody sees an emblem. Worth a
@@ -252,6 +255,8 @@ it touches.
 ****
 * xref:how-to/diagnose-a-problem.adoc[Diagnose a problem] — `wusel doctor`
   produces a redacted report you can attach to a ticket.
+* xref:how-to/set-up-a-notify-hook.adoc[Set up a notify hook] — the one piece of
+  desktop integration a headless box can still have: a script per notice.
 * xref:reference/configuration.adoc[Configuration reference] — the cache budget
   and `refresh_pinned` are the two worth reading for an unattended machine.
 * xref:reference/files-and-directories.adoc[Files and directories] — every path

--- a/documentation/ui-bundle/NOTICE
+++ b/documentation/ui-bundle/NOTICE
@@ -17,6 +17,18 @@ Antora Default UI
   directory). The layouts, partials, helpers, stylesheet, and images in
   this bundle are derived from that project.
 
+Antora lunr extension (css/search.css)
+--------------------------------------
+  https://gitlab.com/antora/antora-lunr-extension
+  Copyright (c) OpenDevise Inc. and the individual contributors to the
+  Antora lunr extension project.
+  Licensed under the Mozilla Public License, v. 2.0 (LICENSE in this
+  directory). css/search.css is derived from the stylesheet shipped with
+  that extension; the extension itself is not vendored here — it is
+  pinned in mise.toml and loaded at build time. Its remaining browser
+  assets (js/search-ui.js, js/vendor/lunr.js) are added to the site by
+  the extension during the build and are not part of this bundle.
+
 highlight.js (js/vendor/highlight.js)
 -------------------------------------
   https://highlightjs.org/

--- a/documentation/ui-bundle/css/search.css
+++ b/documentation/ui-bundle/css/search.css
@@ -1,0 +1,123 @@
+/* Styles for the lunr search UI (@antora/lunr-extension).
+ *
+ * The extension ships a stylesheet of its own and only uses it when the UI
+ * bundle brings none — this file is that opt-out, so the result dropdown wears
+ * the ITBH palette (the --itbh-* variables from site.css) instead of the Antora
+ * default grey. The class names are the extension's contract; keep them.
+ *
+ * Derived from the stylesheet in @antora/lunr-extension, MPL-2.0 — see NOTICE.
+ * The search field itself lives in the navbar and is styled in site.css.
+ */
+
+.search-result-dropdown-menu {
+    position: absolute;
+    z-index: 100;
+    display: block;
+    right: 0;
+    left: inherit;
+    top: 100%;
+    margin: .4rem 0 0;
+    padding: 0;
+    text-align: left;
+    height: auto;
+    background: transparent;
+    border: none;
+    max-width: 600px;
+    min-width: 500px;
+}
+
+@media screen and (max-width:768.5px) {
+    .search-result-dropdown-menu {
+        min-width: calc(100vw - 3.75rem);
+    }
+}
+
+.search-result-dataset {
+    position: relative;
+    border: 1px solid var(--itbh-border);
+    background: #fff;
+    border-radius: .35rem;
+    box-shadow: 0 .5rem 1.5rem rgba(10, 27, 52, .12);
+    overflow: auto;
+    padding: .5rem;
+    max-height: calc(100vh - 5.25rem);
+    line-height: 1.5;
+}
+
+.search-result-item {
+    display: flex;
+    margin-top: .5rem;
+}
+
+/* Component name above its group of hits — only ever shown when the site
+   carries more than one component. */
+.search-result-component-header {
+    color: var(--itbh-navy);
+    border-bottom: 1px solid var(--itbh-border);
+    margin: 0 .5em;
+    padding: .25em 0;
+    font-size: .8rem;
+    font-weight: 500;
+}
+
+.search-result-document-title {
+    width: 33%;
+    border-right: 1px solid var(--itbh-border);
+    color: var(--itbh-navy);
+    font-weight: 500;
+    font-size: .8rem;
+    padding: .5rem .5rem .5rem 0;
+    text-align: right;
+    position: relative;
+    word-wrap: break-word;
+}
+
+.search-result-document-hit {
+    flex: 1;
+    font-size: .75rem;
+    color: #4a5568;
+}
+
+.search-result-document-hit > a {
+    color: inherit;
+    display: block;
+    padding: .55rem .25rem .55rem .75rem;
+    border-radius: .25rem;
+}
+
+.search-result-document-hit > a:hover {
+    background-color: var(--itbh-sky-soft);
+}
+
+.search-result-document-hit .search-result-highlight {
+    color: var(--itbh-blue);
+    background: rgba(26, 143, 227, .12);
+    padding: .1em .05em;
+    font-weight: 500;
+}
+
+.search-result-document-hit .search-result-section-title {
+    color: var(--itbh-navy);
+    font-weight: 500;
+    font-size: 1.05em;
+    margin-bottom: .25em;
+}
+
+.search-result-document-hit .search-result-keywords {
+    margin-top: .25em;
+}
+
+.search-result-document-hit .search-result-keywords-field-label {
+    font-weight: 700;
+}
+
+#search-input:focus {
+    outline: none;
+    border-color: var(--itbh-sky);
+    box-shadow: 0 0 0 2px rgba(26, 143, 227, .2);
+}
+
+#search-field {
+    display: flex;
+    position: relative;
+}

--- a/mise.toml
+++ b/mise.toml
@@ -12,6 +12,9 @@
 rust = { version = "1.97.1", components = "rustfmt,clippy" }  # components explicit: fresh installs (CI) omit them otherwise
 node = "24"                # runtime for the Antora docs (documentation/build.sh)
 "npm:antora" = "3.1.15"    # the `antora` CLI itself — mise manages npm CLIs via the npm backend
+# Full-text search for the docs. Not a CLI but a library antora `require`s;
+# documentation/build.sh points NODE_PATH at this prefix so antora finds it.
+"npm:@antora/lunr-extension" = "1.0.0-alpha.13"
 watchexec = "2.5.1"        # file-event watcher for `build.sh watch` (no busy-waiting)
 "npm:browser-sync" = "3.0.4"  # live-preview server for `build.sh watch` (serve + open browser + reload)
 "ubi:korandoru/hawkeye" = "6.5.1"  # license-header tool (like spotless); see licenserc.toml
@@ -109,7 +112,7 @@ description = "Interactive Linux shell with /dev/fuse (for testing the mount)"
 run = "./scripts/podman-shell.sh"
 
 [tasks.fuse-test]
-description = "Run the Linux-only tests (FUSE mount e2e, network-home relocation) in the container"
+description = "Run the Linux-only tests (FUSE mount e2e, network-home relocation, wusel-desktop's D-Bus/notify-hook path) in the container"
 run = "./scripts/podman-test.sh"
 
 [tasks.e2e-local]

--- a/packaging/rpm/README.md
+++ b/packaging/rpm/README.md
@@ -7,10 +7,15 @@ provider, and the default cloud-provider (sidebar) registration.
 
 ## Build
 
-On a **Fedora** machine (needs `rpm-build gcc make pkgconf nautilus-devel
-glib2-devel fuse3-devel`, plus a Rust toolchain — `mise` is used if present):
+On a **Fedora** machine, with `rpm-build gcc make pkgconf nautilus-devel
+glib2-devel fuse3-devel` **and `rust cargo` installed via `dnf`** (not only
+via `mise` or otherwise on `PATH` — see the comment in `build-rpm.sh` for why
+`rpmbuild --rebuild` needs the `dnf` packages specifically, no matter what
+else provides a working `cargo`):
 
 ```sh
+sudo dnf install rpm-build gcc make pkgconf-pkg-config nautilus-devel \
+    glib2-devel fuse3-devel rust cargo
 ./packaging/rpm/build-rpm.sh
 ```
 

--- a/packaging/rpm/build-rpm.sh
+++ b/packaging/rpm/build-rpm.sh
@@ -13,11 +13,18 @@
 # if you are iterating on something not yet committed; this mirrors what an
 # actual release tag would contain, which is the point of testing this way.
 #
-# Run this ON Fedora (needs: rust >= 1.85, cargo, rpm-build, gcc, make, pkgconf,
-# nautilus-devel, glib2-devel, fuse3-devel — mise is used for the Rust
-# toolchain if present, else the system cargo). To build from a macOS host
-# without a Fedora machine, use scripts/podman-rpm.sh, which runs this inside
-# a Fedora container.
+# Run this ON Fedora, with rpm-build, gcc, make, pkgconf, nautilus-devel,
+# glib2-devel, fuse3-devel, AND rust >= 1.85 / cargo installed via `dnf`
+# specifically — not just on PATH. The `cargo vendor` step below happily uses
+# mise's pinned toolchain if present, but `rpmbuild --rebuild` runs its own
+# %build in a buildroot that resolves wusel.spec's BuildRequires only against
+# installed RPM packages, the same as a real COPR/OBS/`mock` build — mise is
+# invisible there no matter what is on this shell's PATH. Skip the `dnf
+# install` and this script still gets partway (the SRPM builds fine), then
+# fails at the rebuild step with "cargo is needed" / "rust >= 1.85 is needed"
+# even though `cargo --version` works right above it. To build from a macOS
+# host without a Fedora machine, use scripts/podman-rpm.sh, which runs this
+# inside a Fedora container that already has the dnf packages.
 #
 # Options / env:
 #   --check-version    validate the version only (see EXPECT_VERSION) and exit

--- a/scripts/e2e-nextcloud.sh
+++ b/scripts/e2e-nextcloud.sh
@@ -213,6 +213,18 @@ APP_PASS="$(curl -fsS "${ADMIN[@]}" "${OCS_H[@]}" \
 write_curl_rc "$APP_RC" "$NC_USER" "$APP_PASS"
 AUTH=(--config "$APP_RC")
 
+# A quota on the account, so `statfs` has real numbers to report (step 5b).
+# Nextcloud accounts are unlimited by default, and for an unlimited account it
+# answers `quota-available-bytes` with a negative sentinel — which is not a
+# number a filesystem can advertise, so the mount keeps its placeholder. That
+# is correct behaviour, and it is also why this must be set explicitly here:
+# without it the gate below would be testing the fallback, not the feature.
+curl -fsS "${ADMIN[@]}" "${OCS_H[@]}" -X PUT \
+  -d 'key=quota' -d 'value=10 GB' \
+  "$NC_URL/ocs/v2.php/cloud/users/$NC_USER" >/dev/null \
+  || fail "could not set a storage quota on $NC_USER"
+ok "storage quota set to 10 GB on $NC_USER"
+
 mkdir -p "$XDG_CONFIG_HOME/wusel"
 printf '{"server":"%s","loginName":"%s","appPassword":"%s","in_keyring":false}\n' \
   "$(esc "$NC_URL")" "$(esc "$NC_USER")" "$(esc "$APP_PASS")" \
@@ -224,6 +236,9 @@ cat > "$XDG_CONFIG_HOME/wusel/config.toml" <<EOF
 [sync]
 text_merge = true
 revalidate_secs = 3600
+# Low on purpose, for step 13: the quota is changed on the server mid-run and
+# the mount has to notice within the test's patience, not the 60s default.
+quota_revalidate_secs = 2
 [mount]
 dispatch_threads = 4
 EOF
@@ -280,6 +295,45 @@ for i in $(seq 1 30); do
   [ "$i" = 30 ] && fail "mount never showed merge.txt"
 done
 ok "mounted; merge.txt visible"
+
+# --- 5b. statfs reports the server's real quota, not the placeholder --------
+# `df` on the mount must show the account's Nextcloud quota. There is a
+# mock-backed test for this too, but only a real server proves that the
+# PROPFIND we send is one Nextcloud answers with numbers we can actually use:
+# the mock returns a fixture by construction, while a real instance decides for
+# itself (and answers "unlimited"/"not computed" as a negative sentinel, which
+# leaves the mount on its placeholder). A mount stuck on the placeholder looks
+# exactly like a working one until somebody runs `df` — so assert it here.
+echo ">> checking statfs reports the server's real quota ..."
+q_xml="$(curl -fsS "${AUTH[@]}" -X PROPFIND -H 'Depth: 0' -H 'Content-Type: application/xml' \
+  --data '<?xml version="1.0"?><d:propfind xmlns:d="DAV:"><d:prop><d:quota-used-bytes/><d:quota-available-bytes/></d:prop></d:propfind>' \
+  "$DAV/")"
+# Namespace-prefix-agnostic (`d:`, `D:`, none — the server picks): grab the
+# element with its opening tag, then strip everything up to that tag's `>`.
+q_used="$(printf '%s' "$q_xml" | grep -o '<[^>]*quota-used-bytes>[^<]*' | head -1 | sed 's#.*>##')"
+q_avail="$(printf '%s' "$q_xml" | grep -o '<[^>]*quota-available-bytes>[^<]*' | head -1 | sed 's#.*>##')"
+[ -n "$q_avail" ] && [ -n "$q_used" ] || fail "the server did not answer the quota PROPFIND: $q_xml"
+case "$q_avail" in
+  -*) fail "the server reports no usable free space ($q_avail) — the quota set above did not take" ;;
+esac
+want_total=$(( q_used + q_avail ))
+# The mount answers `statfs` from cache and refreshes in the background, so the
+# first reading can still be the placeholder — poll rather than assert once.
+got_total=0
+for _ in $(seq 1 30); do
+    fs_blocks="$(stat -f -c '%b' "$MNT")"
+    fs_bsize="$(stat -f -c '%s' "$MNT")"
+    got_total=$(( fs_blocks * fs_bsize ))
+    # Whole blocks, rounded up — so allow one block of slack either way.
+    if [ "$got_total" -ge $(( want_total - fs_bsize )) ] \
+       && [ "$got_total" -le $(( want_total + fs_bsize )) ]; then
+        break
+    fi
+    sleep 1
+done
+[ "$got_total" -ge $(( want_total - fs_bsize )) ] && [ "$got_total" -le $(( want_total + fs_bsize )) ] \
+  || fail "statfs never reported the server's quota: want ~$want_total bytes, got $got_total"
+ok "statfs reports the server's real quota ($got_total bytes total)"
 
 # --- 5. Read / hydration (also caches the base + its ETag) ------------------
 got="$(cat "$MNT/merge.txt")"
@@ -512,6 +566,57 @@ fi
 else
     skip "step 12 - overlap of concurrent transfers under added latency"
 fi
+
+# --- 13. An account with NO quota must fall back safely --------------------
+# The common case in the field: no quota configured, so Nextcloud answers
+# `quota-available-bytes` with a negative sentinel — no free-space figure a
+# filesystem can advertise. Last, because it changes the account for good.
+# What matters is not the exact number but that the mount stays *usable*:
+# free space must never come out as 0, or applications that check before
+# saving refuse to write at all. Runs after every other gate so the quota is
+# real for those.
+echo ">> removing the account's quota and checking the fallback ..."
+# Retried: this server runs on SQLite and this call lands right after the
+# parallel-transfer steps, where a busy database has answered 500 — a flaky
+# fixture, not a finding about wusel. The gate below is what we are testing.
+quota_cleared=0
+for _ in 1 2 3 4 5; do
+    if curl -fsS "${ADMIN[@]}" "${OCS_H[@]}" -X PUT \
+        -d 'key=quota' -d 'value=none' \
+        "$NC_URL/ocs/v2.php/cloud/users/$NC_USER" >/dev/null 2>&1; then
+        quota_cleared=1
+        break
+    fi
+    sleep 3
+done
+[ "$quota_cleared" = 1 ] || fail "could not clear the storage quota on $NC_USER (5 attempts)"
+q_xml="$(curl -fsS "${AUTH[@]}" -X PROPFIND -H 'Depth: 0' -H 'Content-Type: application/xml' \
+  --data '<?xml version="1.0"?><d:propfind xmlns:d="DAV:"><d:prop><d:quota-available-bytes/></d:prop></d:propfind>' \
+  "$DAV/")"
+q_avail="$(printf '%s' "$q_xml" | grep -o '<[^>]*quota-available-bytes>[^<]*' | head -1 | sed 's#.*>##')"
+echo ">> the server now reports quota-available-bytes=${q_avail:-<absent>}"
+# The mount re-reads on its TTL (config.toml pins it low for this run).
+fb_free=0
+fb_total=0
+for _ in $(seq 1 30); do
+    fs_blocks="$(stat -f -c '%b' "$MNT")"
+    fs_avail="$(stat -f -c '%a' "$MNT")"
+    fs_bsize="$(stat -f -c '%s' "$MNT")"
+    fb_total=$(( fs_blocks * fs_bsize ))
+    fb_free=$(( fs_avail * fs_bsize ))
+    # Left the real 10 GB figure behind → the fallback is in effect.
+    [ "$fb_total" -gt 10737418240 ] && break
+    sleep 1
+done
+[ "$fb_free" -gt 0 ] || fail "an account without a quota left the mount reporting 0 bytes free — applications will refuse to save"
+[ "$fb_total" -gt 10737418240 ] \
+  || fail "the mount never fell back after the quota was removed (total still $fb_total bytes)"
+# `quota-used-bytes` stays a real number even with no quota set, so the used
+# figure must survive the fallback — reporting 0 used would throw it away.
+fb_used=$(( fb_total - fb_free ))
+[ "$fb_used" -gt 0 ] \
+  || fail "the fallback reported 0 bytes used, though the server still knows the real figure"
+ok "no quota on the account → usable fallback ($fb_used bytes used, $fb_free free)"
 
 if [ "$SKIPPED" -gt 0 ]; then
     echo ">> E2E PASSED — but $SKIPPED step(s) were SKIPPED for want of link shaping."

--- a/scripts/podman-test.sh
+++ b/scripts/podman-test.sh
@@ -2,9 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 IT Beratung Hermann GmbH
 
-# Run the FUSE tests in the Linux container (they need /dev/fuse). This is the
-# automated counterpart to `podman-shell.sh` — it runs `cargo test -p wusel-fuse`
-# non-interactively, so the real mount end-to-end is exercised in CI/locally.
+# Run the Linux-only tests in the container (the FUSE ones need /dev/fuse; the
+# wusel-desktop ones need no session D-Bus, which the container simply has
+# none of — the exact headless scenario `[desktop] notify_hook` is for). This
+# is the automated counterpart to `podman-shell.sh` — it runs
+# `cargo test -p wusel-fuse -p wusel-desktop` non-interactively, so both the
+# real mount and the no-D-Bus notify path are exercised in CI/locally.
 #
 # Extra arguments are forwarded to `cargo test`, so the interesting invocations
 # stay inside the script instead of being rebuilt by hand:
@@ -35,15 +38,19 @@ resolve_work
 # silently test the old toolchain. Same in the other podman-*.sh scripts.
 podman build -t "$IMAGE" -f "$REPO/Containerfile" "$REPO"
 
-# With no filter, the whole Linux-only gate runs: the FUSE mount tests plus the
-# network-home proof, which needs a mount namespace and therefore this container
-# too. A filter means somebody is chasing one test, so only that runs.
+# With no filter, the whole Linux-only gate runs: the FUSE mount tests, the
+# network-home proof (needs a mount namespace, hence this container too), and
+# wusel-desktop's `mod linux` — its D-Bus code, and the notify-hook path with
+# no session bus, which is exactly this container's normal state, not
+# something set up specially for the test. A filter means somebody is chasing
+# one test, so only that runs.
 # Clippy belongs here too, not in the native `clippy` task: that one excludes
-# wusel-fuse, because the crate does not build off Linux. So the frontend was
-# the one crate nothing ever linted, and a misplaced `cfg` attribute sat in its
-# crate root for as long as it took somebody to run clippy here by hand.
+# both crates' Linux-gated code, because it does not build off Linux. So the
+# `mod linux` blocks were what nothing ever linted, and a misplaced `cfg`
+# attribute sat in wusel-fuse's crate root for as long as it took somebody to
+# run clippy here by hand.
 if [ "$#" -eq 0 ]; then
-    EXTRA='&& mise exec -- cargo clippy -p wusel-fuse --all-targets -- -D warnings && ./scripts/check-network-home.sh'
+    EXTRA='&& mise exec -- cargo clippy -p wusel-fuse -p wusel-desktop --all-targets -- -D warnings && ./scripts/check-network-home.sh'
 else
     EXTRA=''
 fi
@@ -56,4 +63,4 @@ podman run --rm \
     -v "$WORK":/work:Z \
     -e MISE_TRUSTED_CONFIG_PATHS=/work \
     "$IMAGE" \
-    bash -lc "cd /work && mise exec -- cargo test -p wusel-fuse \"\$@\" $EXTRA" fuse-test "$@"
+    bash -lc "cd /work && mise exec -- cargo test -p wusel-fuse -p wusel-desktop \"\$@\" $EXTRA" fuse-test "$@"


### PR DESCRIPTION
Unreleased work on main, published so it can be built and tested before the
next release carries it.

* **statfs reports the account's real Nextcloud quota.** Where the server names
  a limit, `df ~/Wusel` now shows the account's actual total and free space
  instead of the fixed placeholder, fetched at mount start and refreshed on a
  TTL. Where the server names no limit — an account with no quota — free space
  is genuinely unknown, so the large placeholder stays (as rclone's VFS and
  davfs2 do), but used bytes are now reported truthfully rather than as zero.
  Resolves the request in #30.

* **An opt-in notify hook for headless boxes.** A small script that turns a
  sync event into a desktop notification where there is no desktop to speak of,
  with a how-to guide, working on every platform rather than only Linux.

* **The documentation is searchable.** A client-side lunr index over the Antora
  site, so the manual can be searched without a server.

* Smaller fixes and docs: the RPM readme now says plainly that rust and cargo
  must come from the distribution rather than a stray PATH, and the desktop
  crate's Linux tests run in CI alongside the FUSE ones.